### PR TITLE
Voxxed Days Luxembourg 2020 canceled

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 * [Virtualized] 18: [Cloud Ouest](https://cloudouest.fr/) - France (Nantes)
 * 15-18: [DockerCon](https://www.docker.com/dockercon/) - USA (Austin)
 * 15-18: [O'Reilly Infrastructure and Ops Conference](https://conferences.oreilly.com/infrastructure-ops) - USA (Santa Clara)
-* 18-19: [VoxxedDays Luxembourg](https://luxembourg.voxxeddays.com/) - Luxembourg
+* [Canceled] 18-19: [VoxxedDays Luxembourg](https://luxembourg.voxxeddays.com/) - Luxembourg
 * 23-25: [Spark+AI Summit](https://databricks.com/sparkaisummit) - USA (San Francisco)
 * [Virtualized] End of June [GopherCon Europe](https://gophercon.berlin/) - Germany (Berlin)
 

--- a/README.md
+++ b/README.md
@@ -119,3 +119,7 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 ### May
 
 * xx: [Scala Days Seattle](https://scaladays.org/) - Seattle (USA)
+
+### June
+
+* 21-22: [VoxxedDays Luxembourg](https://luxembourg.voxxeddays.com/) - Luxembourg


### PR DESCRIPTION
https://twitter.com/voxxed_lu/status/1263770037946630144

> Voxxed Days Luxembourg 2020 is now officially (not really a secret though) postponed to next year 😢
> We're pleased to announce Voxxed Days Luxembourg 2021 will take place on June the 21st and 22nd 2021!
> Read more here: https://luxembourg.voxxeddays.com/en/blog/voxxed-days-luxembourg-2020-cancelled/