### PR TITLE
Snowcamp.io canceled

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 
 ### January
 
-* 27-30 [Snowcamp.io](https://snowcamp.io) - France (Grenoble)
+* [Canceled] 27-30 [Snowcamp.io](https://snowcamp.io) - France (Grenoble)
 
 ### April
 


### PR DESCRIPTION
SnowCamp.io 2021 is cancelled
Hello,

It's with regret we announce that SnowCamp 2021 is cancelled. With the evolution of the Covid crisis, we think it's wiser to cancel the 2021 edition of SnowCamp.
Many thanks to the sponsors that were ready to support us for 2021 and to speakers that have already submitted great subjects!
If we can't see you on 2021, we hope to see you from the 2nd to the 5th of February for SnowCamp 2022!

Take care of yourself and your relatives! See you soon!

The SnowCamp.io Team.
PS: if you wish to support us as sponsors, you can contact us to team@snowcamp.io!

Source: [SnowCamp.io 2021 is cancelled](http://u8iw.mjt.lu/nl2/u8iw/miuo2.html?m=AMcAADW15hYAAcrK12gAALEKMxsAAAACR9wAJQJSAAW8XABfcZEL8gp_hQZMTcqKNJA6fL5FTAAFgFs&b=b6b9454d&e=aa386054&x=MFKt7YjejB4pAWf68a3h5FjA2SaL3szAGYdkEtwwzes)