### PR TITLE
feat: add JBCNConf 2021 online edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 * 2: [Riviera Dev](https://rivieradev.fr/) - Roquebrune-sur-Argens (France)
 * 2-3: [Kotland](https://www.papercall.io/kotlandconf2021) - Online
 * 6-7: [JS Italian Conf](https://2021.jsday.it/) - Online
+* 23: [JBNConf](https://www.jbcnconf.com/2021/) - Online
 * 31: [PyOhio](https://www.pyohio.org/2021/) - Online
 
 ### August


### PR DESCRIPTION
JBCNConf 2021 online edition will be held by the Barcelona Java User Group, related to JVM Technologies, microservices, and cloud technologies.