### PR TITLE
Update JChateau with working extra infos

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 * 19-20: [Devoxx Ukraine](https://devoxx.com.ua/) - Online
 * 20-21: [Pycon APAC Thailand 2021](https://th.pycon.org/) - Bangkok (Thailand)
 * 23: [DevDayBE](https://www.devday.be/) - Louvain-La_neuve (Belgium)
-* 24-26: [JChateau / JAlba](https://www.jchateau.org/) - Online
+* <span><details><summary>24-26: <a href="https://www.jchateau.org/">JChateau / JAlba</a> - Online</summary>JChateau et JAlba ont fusionné en 1 unique **non conférence**.</details></span>
 * 29-3/12: [AWS re:Invent](https://reinvent.awsevents.com/) - Las Vegas (USA)
 
 ### December


### PR DESCRIPTION
The collapsible extra infos are now working properly.

Initial problem comes from the use of lines break with HTML tags `<details>` and `<summary>`, which were badly rendered when followed by a new markdown list entry.
Easiest solution to this issue is to inline the whole list entry.