### PR TITLE
Add Kubernetes Community Days Chennai 2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 
 ### June
 
+* 3-4: [Kubernetes Community Days Chennai 2022](http://www.kcdchennai.in) - Chennai (India) + Online <a href="http://www.kcdchennai.in/"><img alt="CFP Kubernetes Community Days Chennai 2022" src="https://img.shields.io/static/v1?label=CFP&message=16-Feb-2022%20to%2031-Mar-2022&color=green"> </a>
 * 7-8: [cdCon](https://events.linuxfoundation.org/cdcon/) - Austin (USA) + Online
 * 9-10: [Le Camping des Speakers](https://camping-speakers.fr/) - Golfe du morbihan (France)
 * 10: [DevFest Lille](http://devfest.gdglille.org) - Lille (France)
@@ -84,4 +85,3 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 ### November
 
 * 7-11: [Devoxx Belgium](https://devoxx.be/) - Antwerp (Belgium)
-* 8-9: [Open Source Experience](https://www.opensource-experience.com/) - Paris (France)


### PR DESCRIPTION
Kubernetes Community Days Chennai 2022 is a two-day Virtual community event for Kubernetes and Cloud-native enthusiasts