### PR TITLE
Adding Serverless Architecture Conference and API conference in April at The Hague (ND)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 
 * 1-2: [GopherCon Brasil](https://gopherconbr.org/) - Online
 * 4-6: [Event Sourcing Live](https://2021.eventsourcing.live/) - Online
+* 4-7: [Jax London](jaxlondon.com) - Online
 * 6: [Virtual Azure Community Day](https://azureday.community/) - Online
 * 5-6: [JS World](https://jsworldconference.com/) - Amsterdam (NL)
 * 5-7: [DevOps Enterprise Summit - DOES](https://events.itrevolution.com/virtual/) - Online
@@ -63,6 +64,8 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 * 19: [DaprCon](https://blog.dapr.io/posts/2021/08/31/announcing-daprcon-2021/) - Online
 * 21-22: [DevFest Nantes](https://devfest.gdgnantes.com/fr/) - Nantes (France)
 * 22: [Go West Online](https://www.gowestconf.com/) - Online 
+* 22-23: [HackConf 2021](https://hackconf.bg/) - Online
+* 25-27: [GopherCon UK](gophercon.co.uk) - The Brewery, City of London (UK)
 
 
 ### November
@@ -73,6 +76,7 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 * (Canceled) 8-12: [Devoxx Belgium](https://www.devoxx.com/) - Belgium
 * 9: [DevFest Strasbourg](https://devfest.gdgstrasbourg.fr/) - Strasbourg (France)
 * 9-10: [Open Source Experience](https://www.opensource-experience.com) - Paris (France) + Online
+* 15-18: [The Agile Testing Days](https://agiletestingdays.com/) - Potsdam, Germany
 * 18: [Codeurs en Seine](https://www.codeursenseine.com/2021) - Online
 * 18: [DevOps DDay](http://devops-dday.com) - Marseille (France)
 * 19: [DevFest Lille](http://devfest.gdglille.org) - Lille (France)
@@ -85,6 +89,7 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 * 5-8: [GopherCon](https://www.gophercon.com/) - Online
 * 6-9: [GOTO Amsterdam 2021](https://gotoams.nl/) - Beurs van Berlage (NL)
 * 8: [ArgoCon '21](https://argoproj.github.io/argocon21/) - San Francisco (USA) & Online
+* 11 : [Continuous Delivery: Better Software Faster](https://devternity.com/) - Online
 
 ## 2022
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 * 5-7: [DevOps Enterprise Summit - DOES](https://events.itrevolution.com/virtual/) - Online
 * 7-8: [Cloud Nord 2021](https://www.cloudnord.fr/) - Online
 * 7-8: [Monktoberfest](https://monktoberfest.com/) - Portland, Maine (USA)
+* 8-10: [Grafana ObservabilityCON](https://grafana.com/about/events/observabilitycon/2021/) - Online
 * 11-15: [KubeCon North America + CloudNativeCon](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/) - Los Angeles Convention Center (USA) + Online
 * 12-14: [Google Cloud Next](https://cloud.withgoogle.com/next/sf/) - Online
 * 12-14: [SRECon](https://www.usenix.org/srecon) - Online

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 * 14: [WAX Watch Awesome Xperts](https://www.waxconf.fr/) - Marseille (France) + Online
 * 21-23: [ContainerDays 2021](https://www.containerdays.io/) - Hamburg (Germany)
 * 22-23: [GitKon 2021](https://gitkon.com) - Online
+* 24: [DevFest Perros-Guirec](https://devfestperros-guirec.com/) - Perros-Guirec (France)
 * 27-2/10: [FOSS4G](https://2021.foss4g.org/) - Online
 * 28: [Serverless Days Paris](https://www.papercall.io/serverless-days-paris-2021) - Paris (France)
 * 28-30: [DevOps World](https://www.devopsworld.com/) - Online

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 ### October
 
 * 1-2: [GopherCon Brasil](https://gopherconbr.org/) - Online
-* 7: [Cloud Nord 2021](https://www.cloudnord.fr/) - Online
+* 7-8: [Cloud Nord 2021](https://www.cloudnord.fr/) - Online
 * 11-15: [KubeCon North America + CloudNativeCon](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/) - Los Angeles Convention Center (USA) + Online
 * 12-14: [Cloud Next](https://cloud.withgoogle.com/next/sf) - Online
 * 12-14: [SRECon](https://www.usenix.org/srecon) - Online

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 * 19-22: [Java Day Istanbul](https://www.javaday.istanbul/) - Antalya (Turkey)
 * 20: [AFUP Day 2022](https://event.afup.org/) - Lille (France)
 * 24-25: [MixIT](https://mixitconf.org/fr/) - Lyon (France) <a href="https://www.papercall.io/mixit2022"><img alt="CFP MixIT 2022" src="https://img.shields.io/static/v1?label=CFP&message=17-Dec-2021%20to%2002-Feb-2022&color=green"> </a>
+* 24-25: [JFrog SwampUp](http://swampup.jfrog.com/) - Omni La Costa Resort & Spa Carlsbad, California (USA) <a href="https://sessionize.com/swampup-2022?utm_campaign=SwampUp+CFP"><img alt="CFP SwampUp2022" src="https://img.shields.io/static/v1?label=CFP&message=16-Dec-2021%20to%2011-Feb-2022&color=green"> </a>
 * 24-26: [Web à Québec](https://webaquebec.org/) - Québec (Canada) <a href="https://yr21i4wwzuv.typeform.com/to/ddNC6Su7"><img alt="CFP Web a Quebec" src="https://img.shields.io/static/v1?label=CFP&message=until%2024-Jan-2022&color=green"> </a>
 * 26-27: [Spring I/O](https://2022.springio.net/) - Barcelona (Spain) <a href="https://www.papercall.io/springio22"><img alt="CFP Spring I/O 2022" src="https://img.shields.io/static/v1?label=CFP&message=23-Dec-2021%20to%2001-Mar-2022&color=green"> </a>
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 
 ### November
 
-* 1-3: [Devoxx UK](https://www.devoxx.uk/) - London (UK)
+* 1-3: [Devoxx UK](https://www.devoxx.co.uk/) - London (UK)
 * 4: [WTF is Cloud Native](https://www.cloud-native-conf.wtf/) - Hybrid conference
 * ?: [Paris Test Conf](https://paristestconf.com/) - Paris (France)
 * 8-12: [Devoxx Belgium](https://www.devoxx.com/) - Belgium

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 
 * 2-3: [Paris Container Day](https://paris-container-day.fr/fr/) - Online
 * 5: [DevRel Con Tokyo 2021](https://tokyo-2021.devrel.net/) - Online
+* 9-10 : [GitOpsDay](https://www.gitopsdays.com/) - online
 * 11: [AFUP Day Toulouse / Tours](https://event.afup.org/afup-day-2021/afup-day-2021-toulouse-tours-edition-en-ligne/) - Online
 * 15-16: [Red Hat Summit 2021 - Part2](https://www.redhat.com/en/summit) - Online
 * 17: [Blazor Day](https://blazorday.net/) - Online

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 
 * 1-2: [GopherCon Brasil](https://gopherconbr.org/) - Online
 * 4-6: [Event Sourcing Live](https://2021.eventsourcing.live/) - Online
-* 4-7: [Jax London](jaxlondon.com) - Online
+* 4-7: [Jax London](https://jaxlondon.com) - Online
 * 6: [Virtual Azure Community Day](https://azureday.community/) - Online
 * 5-6: [JS World](https://jsworldconference.com/) - Amsterdam (NL)
 * 5-7: [DevOps Enterprise Summit - DOES](https://events.itrevolution.com/virtual/) - Online
@@ -65,7 +65,7 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 * 21-22: [DevFest Nantes](https://devfest.gdgnantes.com/fr/) - Nantes (France)
 * 22: [Go West Online](https://www.gowestconf.com/) - Online 
 * 22-23: [HackConf 2021](https://hackconf.bg/) - Online
-* 25-27: [GopherCon UK](gophercon.co.uk) - The Brewery, City of London (UK)
+* 25-27: [GopherCon UK](https://gophercon.co.uk) - The Brewery, City of London (UK)
 
 
 ### November

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 ### November
 
 * 1-3: [Devoxx UK](https://www.devoxx.uk/) - London (UK)
+* 4: [WTF is Cloud Native](https://www.cloud-native-conf.wtf/) - Hybrid conference
 * ?: [Paris Test Conf](https://paristestconf.com/) - Paris (France)
 * 8-12: [Devoxx Belgium](https://www.devoxx.com/) - Belgium
 * 9: [DevFest Strasbourg](https://devfest.gdgstrasbourg.fr/) - Strasbourg (France)

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 * 19-22: [Java Day Istanbul](https://www.javaday.istanbul/) - Antalya (Turkey)
 * 20: [AFUP Day 2022](https://event.afup.org/) - Lille (France)
 * 24-25: [MixIT](https://mixitconf.org/fr/) - Lyon (France) <a href="https://www.papercall.io/mixit2022"><img alt="CFP MixIT 2022" src="https://img.shields.io/static/v1?label=CFP&message=17-Dec-2021%20to%2002-Feb-2022&color=green"> </a>
-* 24-25: [JFrog SwampUp](http://swampup.jfrog.com/) - Omni La Costa Resort & Spa Carlsbad, California (USA) <a href="https://sessionize.com/swampup-2022?utm_campaign=SwampUp+CFP"><img alt="CFP SwampUp2022" src="https://img.shields.io/static/v1?label=CFP&message=16-Dec-2021%20to%2011-Feb-2022&color=green"> </a>
+* 24-26: [JFrog SwampUp](http://swampup.jfrog.com/) - Omni La Costa Resort & Spa Carlsbad, California (USA) <a href="https://sessionize.com/swampup-2022?utm_campaign=SwampUp+CFP"><img alt="CFP SwampUp2022" src="https://img.shields.io/static/v1?label=CFP&message=16-Dec-2021%20to%2011-Feb-2022&color=green"> </a>
 * 24-26: [Web à Québec](https://webaquebec.org/) - Québec (Canada) <a href="https://yr21i4wwzuv.typeform.com/to/ddNC6Su7"><img alt="CFP Web a Quebec" src="https://img.shields.io/static/v1?label=CFP&message=until%2024-Jan-2022&color=green"> </a>
 * 26-27: [Spring I/O](https://2022.springio.net/) - Barcelona (Spain) <a href="https://www.papercall.io/springio22"><img alt="CFP Spring I/O 2022" src="https://img.shields.io/static/v1?label=CFP&message=23-Dec-2021%20to%2001-Mar-2022&color=green"> </a>
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 ### August
 
 * 3-4: [GitLab Commit](https://about.gitlab.com/events/commit/) - Online
+* 18-19: [eBPF Summit](https://ebpf.io/summit-2021/) - Online
 * 18-20: [Gopher Con UK 2021](https://www.gophercon.co.uk/) - Online
 * 25-27: [Devoxx Poland](https://www.devoxx.pl/) - Poland
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 * 14: [WAX Watch Awesome Xperts](https://www.waxconf.fr/) - Marseille (France) + Online
 * 21-23: [ContainerDays 2021](https://www.containerdays.io/) - Hamburg (Germany)
 * 22-23: [GitKon 2021](https://gitkon.com) - Online
-* 24: [DevFest Perros-Guirec](https://devfestperros-guirec.com/) - Perros-Guirec (France)
+* 24: [DevFest Perros-Guirec](https://devfest.codedarmor.fr/) - Perros-Guirec (France)
 * 27-2/10: [FOSS4G](https://2021.foss4g.org/) - Online
 * 28: [Serverless Days Paris](https://www.papercall.io/serverless-days-paris-2021) - Paris (France)
 * 28-30: [DevOps World](https://www.devopsworld.com/) - Online

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 ### April
 
 * 4-6: [QCon London](https://qconlondon.com/) - London (UK)
+* 4-6: [Serverless architecture conference](https://serverless-architecture.io/thehague/) - The Hague Marriot Hotel (Netherlands) or online
+* 4-6: [API Conference](https://apiconference.net/thehague/) - The Hague Marriott Hotel (Netherlands) or online
 * 7-8: [SymfonyLive Paris 2022](https://live.symfony.com/2022-paris/) - Paris (France) <a href="https://live.symfony.com/2022-paris/cfp"><img alt="CFP SymfonyLive Paris 2022" src="https://img.shields.io/static/v1?label=CFP&message=until%2024-Jan-2022&color=green"> </a>
 * 12-14: [DevNexus](https://devnexus.com/) - Atlanta (USA)
 * 20-22: [Devoxx France](https://www.devoxx.fr/) - Paris (France)    <a href="https://cfp.devoxx.fr/"><img alt="CFP Devoxx France" src="https://img.shields.io/static/v1?label=CFP&message=24-Nov-2021-%3E09-Jan-2022&color=green"> </a>

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 
 * 2-3: [Paris Container Day](https://paris-container-day.fr/fr/) - Online
 * 5: [DevRel Con Tokyo 2021](https://tokyo-2021.devrel.net/) - Online
-* 9-10 : [GitOpsDay](https://www.gitopsdays.com/) - online
+* 7-11: [AlpesCraft](https://www.alpescraft.fr/) - Online
+* 9-10 : [GitOpsDay](https://www.gitopsdays.com/) - Online
+* 14-17 : [DevOpsCon](https://devopscon.io/berlin/) - Online
 * 11: [AFUP Day Toulouse / Tours](https://event.afup.org/afup-day-2021/afup-day-2021-toulouse-tours-edition-en-ligne/) - Online
 * 15-16: [Red Hat Summit 2021 - Part2](https://www.redhat.com/en/summit) - Online
 * 17: [Blazor Day](https://blazorday.net/) - Online
@@ -84,13 +86,17 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 * 21-23: [ContainerDays 2021](https://www.containerdays.io/) - Hamburg (Germany)
 * 28: [Serverless Days Paris](https://www.papercall.io/serverless-days-paris-2021) - Paris (France)
 * 28-30: [DevOps World](https://www.devopsworld.com/) - Online
+* 29-30: [AnsibleFest](https://www.ansible.com/ansiblefest) - Online
 * 29-1/10: [Devoxx France](https://www.devoxx.fr/) - Paris (France)
+* 29-1/10: [ApacheCon](https://apachecon.com/acna2020/) - Online
 
 ### October
 
 * 1-2: [GopherCon Brasil](https://gopherconbr.org/) - Online
+* 5-7: [DevOps Enterprise Summit - DOES](https://events.itrevolution.com/virtual/) - Online
 * 7-8: [Cloud Nord 2021](https://www.cloudnord.fr/) - Online
 * 11-15: [KubeCon North America + CloudNativeCon](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/) - Los Angeles Convention Center (USA) + Online
+* 12-14: [Google Cloud Next](https://cloud.withgoogle.com/next/sf/) - Online
 * 12-14: [Cloud Next](https://cloud.withgoogle.com/next/sf) - Online
 * 12-14: [SRECon](https://www.usenix.org/srecon) - Online
 * 21-22: [DevFest Nantes](https://devfest.gdgnantes.com/fr/) - Nantes (France)
@@ -106,10 +112,12 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 * 19: [DevFest Lille](http://devfest.gdglille.org) - Lille
 * 19-20: [Devoxx Ukraine](https://www.devoxx.ua/) - Online
 * 20-21: [Pycon APAC Thailand 2021](https://th.pycon.org/) - Bangkok
+* 29-3/12: [AWS re:Invent](https://reinvent.awsevents.com/)
 
 ### December
 
 * 5-8: [GopherCon](https://www.gophercon.com/) - Online
+* 6-9: [GOTO Amsterdam 2021](https://gotoams.nl/) - Beurs van Berlage
 
 ## 2022
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 * 2-3: [Paris Container Day](https://paris-container-day.fr/fr/) - Online
 * 5: [DevRel Con Tokyo 2021](https://tokyo-2021.devrel.net/) - Online
 * 7-11: [AlpesCraft](https://www.alpescraft.fr/) - Online
+* 8-11: [HashiConf Europe](https://hashiconf.com/europe/) - Online
 * 9-10 : [GitOpsDay](https://www.gitopsdays.com/) - Online
 * 14-17 : [DevOpsCon](https://devopscon.io/berlin/) - Online
 * 11: [AFUP Day Toulouse / Tours](https://event.afup.org/afup-day-2021/afup-day-2021-toulouse-tours-edition-en-ligne/) - Online

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 * 4-6: [Event Sourcing Live](https://2021.eventsourcing.live/) - Online
 * 5-7: [DevOps Enterprise Summit - DOES](https://events.itrevolution.com/virtual/) - Online
 * 7-8: [Cloud Nord 2021](https://www.cloudnord.fr/) - Online
+* 7-8: [Monktoberfest](https://monktoberfest.com/) - Portland, Maine (USA)
 * 11-15: [KubeCon North America + CloudNativeCon](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/) - Los Angeles Convention Center (USA) + Online
 * 12-14: [Google Cloud Next](https://cloud.withgoogle.com/next/sf/) - Online
 * 12-14: [SRECon](https://www.usenix.org/srecon) - Online

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 * 10: [JUG Summer Camp](https://www.jugsummercamp.org/edition/12) - La Rochelle (France)
 * 10: [API Platform Conference](https://api-platform.com/con/2021/) - Lille (France) & Online for track EN
 * 10-12: [International Sketchnote Camp 2021](https://isc20be.home.blog/registration/) - Brussels & Online
+* 13: [.NET Enterprise Developer Day hosted by Amazon Web Services](https://www.eventbrite.com/e/net-enterprise-developer-day-hosted-by-amazon-web-services-registration-167917464657) - Online
+* 13-14: [DeveloperWeek Global: Cloud Conference](https://www.developerweek.com/global/conference/cloud/) - Online
 * 14: [WAX Watch Awesome Xperts](https://www.waxconf.fr/) - Marseille (France) + Online
 * 21-23: [ContainerDays 2021](https://www.containerdays.io/) - Hamburg (Germany)
 * 22-23: [GitKon 2021](https://gitkon.com) - Online


### PR DESCRIPTION
I suggest adding 2 more conferences to come:  
- Serverless Architecture Conference 
-  API conference in April

Both are located the same days on the same place at The Hague (ND)