### PR TITLE
Add Mars@Hack Event

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 * 5-6: [Fosdem](https://fosdem.org/2022/) - Brussels (Belgium)
 * 7-8: [DevOpsDays Geneva](https://devopsdays.org/events/2022-geneva/welcome/) - Geneva (Switzerland)
 * 10: [.Net frontend Day](https://www.dotnet-frontend.com/) - Online 
+* 10: [Dataquitaine](https://www.dataquitaine.com/2022/conference-ia-ai-datascience-ro-bordeaux-2022) - Online
 * 11-12: [Elastic Community Conference](https://sessionize.com/elastic-community-conference) - Online 
 * 22-25: [ConFoo](https://confoo.ca/fr/2022) - Montreal (Canada) & Online
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 * 11-13: [PyCon DE & PyData Berlin](https://2022.pycon.de/) - Berlin (Germany)
 * 12-14: [DevNexus](https://devnexus.com/) - Atlanta (USA)
 * 13-14: [DevOpsDays raleigh](https://devopsdays.org/events/2022-raleigh/welcome/) - Raleigh (USA)
+* 14-15: [THCon](https://thcon.party/) - Toulouse (France)
 * 18-19: [devopsdays Birmingham, AL](https://devopsdays.org/events/2022-birmingham-al/welcome/) - Birmingham (USA)
 * 19-20: [DevOpsDays Atlanta](https://devopsdays.org/events/2022-atlanta/welcome/) - Atlanta (USA)
 * 21-22: [JSDay](https://2022.jsday.it/) - Verona (Italy)

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ This tech conferences agenda list can be seen in https://developers.events/
 * 3: [Le Tremplin des Speakers](https://conference-hall.io/public/event/YWp80xxngUcObepMyFCJ) - Tours (France) <a href="https://conference-hall.io/public/event/YWp80xxngUcObepMyFCJ"><img alt="CFP Le Tremplin des Speakers 2022" src="https://img.shields.io/static/v1?label=CFP&message=1-Mar-2022%20to%2026-Mar-2022&color=red"> </a>
 * 4-5: [PulumiUP](https://www.pulumi.com/pulumi-up/) - Online
 * 5-7: [JSDay canarias](https://jsdaycanarias.com/) - Islas Canarias (España)
+* 6: [Mars@Hack](http://www.montdemarsan-agglo.fr/agglo/jsp/site/Portal.jsp?page_id=547) - Mont de Marsan (France)
 * 9-12: [SLOConf](https://www.sloconf.com/) - Online <a href="https://www.papercall.io/sloconf"><img alt="CFP SLOConf" src="https://img.shields.io/static/v1?label=CFP&message=05-Jan-2022%20to%2008-Mar-2022&color=red"> </a>
 * 10: [Docker Con](https://www.docker.com/dockercon/) - Online
 * 10-20: [QCon Plus](https://qconlondon.com/) - Online

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 * 3-4: [Kubernetes Community Days Chennai 2022](http://www.kcdchennai.in) - Chennai (India) + Online <a href="http://www.kcdchennai.in/"><img alt="CFP Kubernetes Community Days Chennai 2022" src="https://img.shields.io/static/v1?label=CFP&message=16-Feb-2022%20to%2031-Mar-2022&color=green"> </a>
 * 7-8: [LeadDev](https://leaddev.com/) - UK
 * 7-8: [cdCon](https://events.linuxfoundation.org/cdcon/) - Austin (USA) + Online <a href="https://events.linuxfoundation.org/cdcon/program/cfp/"><img alt="CFP cdCon" src="https://img.shields.io/static/v1?label=CFP&message=10-Jan-2022%20to%2018-Feb-2022&color=green"> </a>
+* 7-9: [Forum International de la Cybersécurité](https://www.forum-fic.com/) - Lille (FR)
 * 9-10: [Le Camping des Speakers](https://camping-speakers.fr/) - Golfe du morbihan (France) <a href="https://conference-hall.io/public/event/0Ij6N6UQOInRF9fdEm6G"><img alt="CFP Le Camping des Speakers 2022" src="https://img.shields.io/static/v1?label=CFP&message=7-Dec-2021%20to%2020-Feb-2022&color=green"> </a>
 * 9-10: [AlpesCraft](https://www.alpescraft.fr/) - Grenoble (France)
 * 10: [DevFest Lille](http://devfest.gdglille.org) - Lille (France) <a href="https://conference-hall.io/public/event/vzbfowsExm54SrWLtxA5"><img alt="CFP DevFest Lille 2022" src="https://img.shields.io/static/v1?label=CFP&message=24-Jan-2022%20to%2031-Mar-2022&color=green"> </a>

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ If they don't know your conference they can't buy a ticket and come to it 😏.
 * 14-16: [SRECon22 Americas](https://www.usenix.org/conference/srecon22americas) - San Francisco (USA)
 * 15-17: [JavaLand](https://www.javaland.eu/en/home/) - Brühl (Germany)
 * 18: [Mobilis In Mobile](https://mobilis-in-mobile.io/) - Nantes (France) <a href="https://conference-hall.io/public/event/7MA75159U7eqMByzxmrZ"><img alt="CFP Mobilis In Mobile" src="https://img.shields.io/static/v1?label=CFP&message=01-Dec-2021-%3E31-Jan-2022&color=red"> </a>
+* 22-23: [SEO Square](https://seosquare.semji.com/) - Online
 * 23-25: [VoxxedDays Bucharest](https://romania.voxxeddays.com/bucharest/voxxed-days-bucharest-2022/) - Bucharest (Romania) & Online
 * 24: [Cloud Sud](https://cloudsud.fr) - Online <a href="https://conference-hall.io/public/event/lEimlpsjR1JfydbTWvzY"><img alt="CFP Cloud Sud" src="https://img.shields.io/static/v1?label=CFP&message=Until%2019-Feb-2022&color=red"> </a>
 * 28: [Incontro DevOps Italia](https://2022.incontrodevops.it/) - Bologna (Italia) & Online


### PR DESCRIPTION
Mars@Hack est un évènement local dédié à la cybersécurité, avec 
- une compétition de type CTF accessible en local mais aussi à distance
- des conférences techniques et organisationnelle dédiées aux entreprises