### PR TITLE
Add DevOps World 2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ This tech conferences agenda list can be seen in https://developers.events/
 * 14-15: [Uptime](https://uptime.aiven.io) - Amsterdam (NL)
 * 24: [PyCon Portugal](http://2022.pycon.pt/) - Porto (Portugal)
 * 26-28: [GopherCon](https://www.gophercon.com/) - Florida (USA)
+* 28-29: [DevOps World 2022](https://www.cloudbees.com/c/devops-world-2022-save-the-date) - Orlando, Florida (USA) <a href="https://assets.cloudbees.com/MzMzLVFQVi03MjUAAAGEENe8Ddj2m2ND8y469mGfpl-u3PnjGNmJ2wz1pWCNco6e5XhiUbm3cpDALNvRK1BeUFbLmmQ="><img alt="CFP DevOps World 2022" src="https://img.shields.io/static/v1?label=CFP&message=until%2013-May-2022&color=green"> </a>
 * 29: [Cloud Nord](https://cloudnord.fr/) - Lille (France) <a href="https://conference-hall.io/public/event/wGVYkl21UFxeiuakhKfu"><img alt="CFP Cloud Nord 2022" src="https://img.shields.io/static/v1?label=CFP&message=until%2031-May-2022&color=green"> </a>
 
 ### October


### PR DESCRIPTION
## Description

Adding [DevOps World 2022](https://www.cloudbees.com/c/devops-world-2022-save-the-date) for Septembrer *(28-29)* + CFP until May 13