### PR TITLE
chore: add CFP for BDX IO 2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ This tech conferences agenda list can be seen in https://developers.events/
 ### December
 
 * 1: [Devops DDay #7](https://2022.devops-dday.com/) - Marseille (France) <a href="https://conference-hall.io/public/event/eKYGzptI6y44zoS8sGUz"><img alt="CFP Devops DDay" src="https://img.shields.io/static/v1?label=CFP&message=until%2030-Jun-2022&color=green"> </a>
-* 2: [BDX I/O](https://www.bdxio.fr/) - Bordeaux (France) 
+* 2: [BDX I/O](https://www.bdxio.fr/) - Bordeaux (France) <a href="https://conference-hall.io/public/event/OJC5Ou5YJodfetgSJCa3"><img alt="CFP BDX I/O" src="https://img.shields.io/static/v1?label=CFP&message=until%2031-Jul-2022&color=green"> </a>
 * 5-8: [DevOpsCon Munich](https://devopscon.io/call-for-papers/) - Munich (Germany) <a href="https://devopscon.io/call-for-papers/"><img alt="CFP DevOpsCon Munich" src="https://img.shields.io/static/v1?label=CFP&message=until%2027-Jun-2022&color=green"> </a>
 * 7-9: [SREcon22 Asia/Pacific](https://www.usenix.org/srecon) - Sydney (Australia)
 * 14-16: [API Days Paris](https://www.apidays.global/paris/) - Paris (France) & Online


### PR DESCRIPTION
Hello scraly

I just received an email from BDX I/O giving the CFP dates and links for 2022 edition

(Have fun at Le camping des speakers ;-p)