### PR TITLE
Fix end date computation in parser.py (fixes #319)

### DIFF
--- a/tools/parser.py
+++ b/tools/parser.py
@@ -1,6 +1,4 @@
 import sys
-import os
-import os.path as path
 from datetime import datetime
 import json
 
@@ -48,6 +46,12 @@ def parse_date(y, m, s):
 			datEnd = datetime(y, _m, _d)
 		else:
 			datEnd = datetime(y, m, int(components[1]))
+			# for dates such as '27-01: Elastic{ON} - USA (San Francisco)'
+			if datEnd < datStart:
+				if datStart.month < 12:
+					datEnd = datetime(y, datEnd.month + 1, datEnd.day)
+				else:
+					datEnd = datetime(y + 1, 1, datEnd.day)
 
 	return [
 		int(datStart.timestamp()),


### PR DESCRIPTION
Diff between old json and new json (timezone = Europe/Paris) :

```json
--- oldf.json	2023-01-05 22:00:58.083757282 +0100
+++ newf.json	2023-01-05 22:01:03.043911122 +0100
@@ -853,7 +853,7 @@
     "name": "Elastic{ON}",
     "date": [
       1519686000,
-      1517439601
+      1519858801
     ],
     "hyperlink": "https://www.elastic.co/elasticon/conf/2018/sf",
     "location": "USA (San Francisco)",
@@ -1363,7 +1363,7 @@
     "name": "Gopher Con Iceland",
     "date": [
       1527717600,
-      1525298401
+      1527976801
     ],
     "hyperlink": "https://gophercon.is/",
     "location": "Iceland",
@@ -1603,7 +1603,7 @@
     "name": "La nuit du Hack",
     "date": [
       1530309600,
-      1527804001
+      1530396001
     ],
     "hyperlink": "https://www.nuitduhack.com/fr",
     "location": "France (Paris)",
@@ -2253,7 +2253,7 @@
     "name": "DockerCon 2019",
     "date": [
       1556488800,
-      1554156001
+      1556748001
     ],
     "hyperlink": "https://dockercon19.smarteventscloud.com/portal/newreg.ww",
     "location": "USA (San Francisco)",
@@ -2263,7 +2263,7 @@
     "name": "Rails Conf",
     "date": [
       1556575200,
-      1554156001
+      1556748001
     ],
     "hyperlink": "https://railsconf.com/",
     "location": "USA (Minneapolis)",
@@ -2473,7 +2473,7 @@
     "name": "GopherCon Europe",
     "date": [
       1559167200,
-      1556661601
+      1559340001
     ],
     "hyperlink": "https://www.gophercon.es",
     "location": "Tenerife",
@@ -4883,7 +4883,7 @@
     "name": "web3 Con",
     "date": [
       1646002800,
-      1644102001
+      1646521201
     ],
     "hyperlink": "https://www.web3con.dev/",
     "location": "Online",
@@ -5303,7 +5303,7 @@
     "name": "PyCon US",
     "date": [
       1651010400,
-      1648936801
+      1651528801
     ],
     "hyperlink": "https://us.pycon.org/2022/",
     "location": "Salt Lake City (USA)",
@@ -5773,7 +5773,7 @@
     "name": "Craft Conference",
     "date": [
       1653948000,
-      1651528801
+      1654207201
     ],
     "hyperlink": "https://craft-conf.com/",
     "location": "Budapest (Hungary) ",
@@ -6173,7 +6173,7 @@
     "name": "Hack in Paris",
     "date": [
       1656280800,
-      1654034401
+      1656626401
     ],
     "hyperlink": "https://hackinparis.com/",
     "location": "Paris (France) ",
@@ -6203,7 +6203,7 @@
     "name": "BreizhCamp",
     "date": [
       1656453600,
-      1654034401
+      1656626401
     ],
     "hyperlink": "https://www.breizhcamp.org/",
     "location": "Rennes (France) ",
@@ -6213,7 +6213,7 @@
     "name": "Sunny Tech",
     "date": [
       1656540000,
-      1654034401
+      1656626401
     ],
     "hyperlink": "https://sunny-tech.io/",
     "location": "Montpellier (France) ",
@@ -6223,7 +6223,7 @@
     "name": "Agi'Lille 2022",
     "date": [
       1656540000,
-      1654034401
+      1656626401
     ],
     "hyperlink": "https://agilille.fr/",
     "location": "Lille (France) ",
```