### PR TITLE
Add German Perl and Raku Workshop 2023

### DIFF
--- a/archives/2023.md
+++ b/archives/2023.md
@@ -47,7 +47,7 @@
 * 23: [Testing, Agile, DevOps and Low code Showcase - Methods and Tools](https://www.unicomlearning.com/agile-devops-software-testing-conference/bengaluru-india-2023/) - Bengaluru (India)
 * 23-24: [KCD - Kubernetes Community Days Amsterdam 2023](https://community.cncf.io/events/details/cncf-kcd-netherlands-presents-kubernetes-community-days-amsterdam-2023/) - Amsterdam (NL)
 * 25-26: [Laracon India](https://laracon.in/) - Ahmedabad (India)
-* 27-01: [German Perl and Raku Workshop](https://perl-raku-workshop.de/) - Frankfurt (Germany)
+* 27-01/03: [German Perl and Raku Workshop](https://perl-raku-workshop.de/) - Frankfurt (Germany)
 
 ### March
 

--- a/archives/2023.md
+++ b/archives/2023.md
@@ -47,7 +47,7 @@
 * 23: [Testing, Agile, DevOps and Low code Showcase - Methods and Tools](https://www.unicomlearning.com/agile-devops-software-testing-conference/bengaluru-india-2023/) - Bengaluru (India)
 * 23-24: [KCD - Kubernetes Community Days Amsterdam 2023](https://community.cncf.io/events/details/cncf-kcd-netherlands-presents-kubernetes-community-days-amsterdam-2023/) - Amsterdam (NL)
 * 25-26: [Laracon India](https://laracon.in/) - Ahmedabad (India)
-* 27-01: [German Perl and Raku Workshop](https://act.yapc.eu/gpw2023/) - Frankfurt (Germany)
+* 27-01: [German Perl and Raku Workshop](https://perl-raku-workshop.de/) - Frankfurt (Germany)
 
 ### March
 

--- a/archives/2023.md
+++ b/archives/2023.md
@@ -47,6 +47,7 @@
 * 23: [Testing, Agile, DevOps and Low code Showcase - Methods and Tools](https://www.unicomlearning.com/agile-devops-software-testing-conference/bengaluru-india-2023/) - Bengaluru (India)
 * 23-24: [KCD - Kubernetes Community Days Amsterdam 2023](https://community.cncf.io/events/details/cncf-kcd-netherlands-presents-kubernetes-community-days-amsterdam-2023/) - Amsterdam (NL)
 * 25-26: [Laracon India](https://laracon.in/) - Ahmedabad (India)
+* 27-01: [German Perl and Raku Workshop](https://act.yapc.eu/gpw2023/) - Frankfurt (Germany)
 
 ### March
 


### PR DESCRIPTION
Hi,

thanks for this nice calendar.

This PR add the German Perl and Raku Workshop, that took place in February this year in Frankfurt (Germany).

Kind regards
Renée