### PR TITLE
Add Perl and Koha conference 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ All the data (past and coming) is available publicly in JSON:
 * 1-2: [DevOpsDays Seattle](https://devopsdays.org/events/2023-seattle/welcome/)
 * 4-5: [Beer City Code](https://www.beercitycode.com/) - Grand Rapids, Michigan (USA) <a href="https://sessionize.com/beer-city-code-2023/"><img alt="Beer City Code" src="https://img.shields.io/static/v1?label=CFP&message=from%203-february-2023%20to%2015-april-2023&color=green"></a>
 * 9-10: [DevOpsDays Chicago](https://devopsdays.org/chicago) - Chicago (USA)
+* 14-18: [Perl and Koha Conference](https://perlkohacon.fi/) - Helsinki (Finland) <a href="https://perlkohacon.fi/Call-For-Talks-Perl-Koha-Helsinki-August-2023.html"><img alt="CFP PerlKohaCon 2023" src="https://img.shields.io/static/v1?label=CFP&message=until%2030-April-2023&color=red"></a>
 * 16-18: [GopherCon UK 2023](https://www.gophercon.co.uk) - London (UK)
 * 28-01/09: [VLDB Very Large Database](https://vldb.org/2023/) - Vancouver (Canada)
 * 28-01/09: [NDC Copenhagen](https://cphdevfest.com/) - Copenhagen (Denmark)

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ All the data (past and coming) is available publicly in JSON:
 * 1-2: [DevOpsDays Seattle](https://devopsdays.org/events/2023-seattle/welcome/)
 * 4-5: [Beer City Code](https://www.beercitycode.com/) - Grand Rapids, Michigan (USA) <a href="https://sessionize.com/beer-city-code-2023/"><img alt="Beer City Code" src="https://img.shields.io/static/v1?label=CFP&message=from%203-february-2023%20to%2015-april-2023&color=green"></a>
 * 9-10: [DevOpsDays Chicago](https://devopsdays.org/chicago) - Chicago (USA)
-* 14-18: [Perl and Koha Conference](https://perlkohacon.fi/) - Helsinki (Finland) <a href="https://perlkohacon.fi/Call-For-Talks-Perl-Koha-Helsinki-August-2023.html"><img alt="CFP PerlKohaCon 2023" src="https://img.shields.io/static/v1?label=CFP&message=until%2030-April-2023&color=red"></a>
+* 14-18: [Perl and Koha Conference](https://perlkohacon.fi/) - Helsinki (Finland) <a href="https://perlkohacon.fi/Call-For-Talks-Perl-Koha-Helsinki-August-2023.html"><img alt="CFP PerlKohaCon 2023" src="https://img.shields.io/static/v1?label=CFP&message=until%2030-April-2023&color=green"></a>
 * 16-18: [GopherCon UK 2023](https://www.gophercon.co.uk) - London (UK)
 * 28-01/09: [VLDB Very Large Database](https://vldb.org/2023/) - Vancouver (Canada)
 * 28-01/09: [NDC Copenhagen](https://cphdevfest.com/) - Copenhagen (Denmark)


### PR DESCRIPTION
Koha is a conference written in Perl. This conference combines the two former conferences YAPC::Europe (Yet another Perl conference) and KohaCon...