### PR TITLE
By setting the base date background color to white, the days without events become white, and the days with at least an event become some shade of gray. So we clearly see the difference between days with and without events.

### DIFF
--- a/page/src/styles/Calendar.css
+++ b/page/src/styles/Calendar.css
@@ -30,7 +30,7 @@
 .date {
   padding: 10px;
   text-align: center;
-  background: #eee;
+  background: #fff;
   border-radius: 3px;
   cursor: pointer;
 }


### PR DESCRIPTION
fixes #424