### PR TITLE
Adjust .intensity-4 text color

### DIFF
--- a/page/src/styles/Calendar.css
+++ b/page/src/styles/Calendar.css
@@ -49,7 +49,6 @@
 }
 .date.intensity-4 {
   background-color: rgb(148 163 184);
-  color: #fafafa;
 }
 .date.intensity-5 {
   background-color: rgb(100 116 139);


### PR DESCRIPTION
The .date.intensity-4 text color vs. its background color is failing WCAG 2 contrast standards. Removing the color property fixes this.

Testing source: [webaim.org](https://webaim.org/resources/contrastchecker/)

❌ Fail
====
<img src="https://user-images.githubusercontent.com/12941979/235740537-ee8a13a2-a518-45a2-ac09-64bbc3098404.png" alt="failing WCAG 2 color contrast check" width="500px" />

✅ Pass
====
<img src="https://user-images.githubusercontent.com/12941979/235740521-f171ebef-503d-4a67-b8db-4d2bdc8795b6.png" alt="passing WCAG 2 color contrast check" width="500px" />
