### PR TITLE
feat: publish ics as static ressources

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -26,6 +26,7 @@ jobs:
         run: |
           node mdValidator.js
           node mdParser.js
+          node generateIcs.js
       - working-directory: page
         run: npm run build
       - name: Make all-*.json files available at the site root
@@ -33,6 +34,7 @@ jobs:
         run: |
           mv ../page/src/misc/all-events.json ../page/build/all-events.json
           mv ../page/src/misc/all-cfps.json ../page/build/all-cfps.json
+          mv ../page/src/misc/*.ics ../page/build/
       - name: Deploy to GitHub Pages
         if: github.ref_name == 'main'
         uses: crazy-max/ghaction-github-pages@v2

--- a/page/.gitignore
+++ b/page/.gitignore
@@ -25,3 +25,4 @@ yarn-error.log*
 *~
 all-events.json
 all-cfps.json
+developer-conference-*.ics

--- a/page/src/App.js
+++ b/page/src/App.js
@@ -1,17 +1,16 @@
-import {useReducer, useState} from 'react';
+import { useReducer, useState } from 'react';
 
-import {IonIcon} from '@ionic/react';
-import {arrowDownCircle} from 'ionicons/icons';
+import { IonIcon } from '@ionic/react';
+import { arrowDownCircle } from 'ionicons/icons';
 
-import YearSelector from 'components/YearSelector/YearSelector';
 import CalendarGrid from 'components/CalendarGrid/CalendarGrid';
+import YearSelector from 'components/YearSelector/YearSelector';
 
-import 'misc/fonts/inter/inter.css';
-import 'styles/App.css';
-import {exportYear} from 'utils';
+import CustomContext from 'app.context';
 import reducer from 'app.reducer';
 import SelectedEvents from 'components/SelectedEvents/SelectedEvents';
-import CustomContext from 'app.context';
+import 'misc/fonts/inter/inter.css';
+import 'styles/App.css';
 
 const App = () => {
   const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
@@ -30,10 +29,10 @@ const App = () => {
           setSelectedYear(year);
         }}
       />
-      <div className="downloadButton" onClick={() => exportYear(selectedYear)}>
+      <a href={'/developer-conference-' + selectedYear + '.ics'} className="downloadButton">
         <IonIcon icon={arrowDownCircle} />
         Download {selectedYear} Calendar
-      </div>
+      </a>
 
       <CalendarGrid year={selectedYear} />
 

--- a/page/src/App.js
+++ b/page/src/App.js
@@ -11,6 +11,7 @@ import reducer from 'app.reducer';
 import SelectedEvents from 'components/SelectedEvents/SelectedEvents';
 import 'misc/fonts/inter/inter.css';
 import 'styles/App.css';
+import {hasEvents} from "./utils";
 
 const App = () => {
   const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
@@ -29,10 +30,12 @@ const App = () => {
           setSelectedYear(year);
         }}
       />
-      <a href={'/developer-conference-' + selectedYear + '.ics'} className="downloadButton">
+        {
+            hasEvents(selectedYear) && <a href={'/developer-conference-' + selectedYear + '.ics'} className="downloadButton">
         <IonIcon icon={arrowDownCircle} />
         Download {selectedYear} Calendar
       </a>
+        }
 
       <CalendarGrid year={selectedYear} />
 

--- a/page/src/styles/App.css
+++ b/page/src/styles/App.css
@@ -10,6 +10,8 @@ body {
 }
 
 .downloadButton {
+  text-decoration: none;
+  color: black;
   width: max-content;
   margin: 1rem auto;
   padding: 10px;

--- a/page/src/utils.js
+++ b/page/src/utils.js
@@ -1,5 +1,4 @@
 import allEvents from 'misc/all-events.json';
-import {VCALENDAR, VEVENT} from 'ics-js';
 
 const appendEvent = (events, date, event) => {
   if (!events[date.getFullYear()]) events[date.getFullYear()] = {};
@@ -31,31 +30,7 @@ export const getEventsByYear = () => {
   window.dev_events = events;
 };
 
-export const exportYear = selectedYear => {
-  let cal = new VCALENDAR();
-  cal.addProp('VERSION', 2);
-  cal.addProp('PRODID', 'DCA');
-
-  for (const event of allEvents) {
-    let eventYear = new Date(event.date[0]).getFullYear();
-    if (eventYear !== selectedYear) continue;
-    let vevent = new VEVENT();
-    vevent.addProp('UID', `${Math.random()}@dca`);
-    vevent.addProp('DTSTAMP', new Date());
-    vevent.addProp('DTSTART', new Date(event.date[0]));
-    vevent.addProp('DTEND', new Date(event.date[1] ?? event.date[0]));
-    vevent.addProp('LOCATION', event.location || 'unspecified');
-    vevent.addProp('SUMMARY', event.name);
-    vevent.addProp('URL', event.hyperlink || 'unspecified');
-    cal.addComponent(vevent);
-  }
-
-  let blob = cal.toBlob();
-  let link = document.createElement('a');
-  link.href = URL.createObjectURL(blob);
-  link.download = `developer-conference-${selectedYear}.ics`;
-  link.click();
-};
+export const hasEvents = (year) => Boolean(allEvents.find(e => new Date(e.date[0]).getFullYear() === year))
 
 const lpad2 = number => ('0' + number).slice(-2);
 

--- a/run.sh
+++ b/run.sh
@@ -8,6 +8,7 @@ npm install -D --force
 cd ../tools
 node mdValidator.js
 node mdParser.js
+node generateIcs.js
 
 cd ../page
 npm start

--- a/tools/generateIcs.js
+++ b/tools/generateIcs.js
@@ -12,7 +12,7 @@ for (const event of allEvents) {
         cals[eventYear].addProp('PRODID', 'DCA');
     }
     let vevent = new VEVENT();
-    vevent.addProp('UID', `${Math.random()}@dca`);
+    vevent.addProp('UID', `${event.name}@dca-${eventYear}`);
     vevent.addProp('DTSTAMP', new Date());
     vevent.addProp('DTSTART', new Date(event.date[0] * 1000));
     vevent.addProp('DTEND', new Date(event.date[1] * 1000));

--- a/tools/generateIcs.js
+++ b/tools/generateIcs.js
@@ -1,0 +1,29 @@
+const fs = require("fs");
+const { VCALENDAR, VEVENT } = require('../page/node_modules/ics-js');
+
+const allEvents = JSON.parse(fs.readFileSync('../page/src/misc/all-events.json'), 'utf-8');
+const cals = {};
+
+for (const event of allEvents) {
+    let eventYear = new Date(event.date[0]).getFullYear();
+    if (!cals[eventYear]) {
+        cals[eventYear] = new VCALENDAR();
+        cals[eventYear].addProp('VERSION', 2);
+        cals[eventYear].addProp('PRODID', 'DCA');
+    }
+    let vevent = new VEVENT();
+    vevent.addProp('UID', `${Math.random()}@dca`);
+    vevent.addProp('DTSTAMP', new Date());
+    vevent.addProp('DTSTART', new Date(event.date[0] * 1000));
+    vevent.addProp('DTEND', new Date(event.date[1] * 1000));
+    vevent.addProp('LOCATION', event.location || 'unspecified');
+    vevent.addProp('SUMMARY', event.name);
+    vevent.addProp('URL', event.hyperlink || 'unspecified');
+    cals[eventYear].addComponent(vevent);
+}
+
+Object.keys(cals).forEach(year => fs.writeFileSync(
+    `../page/src/misc/developer-conference-${year}.ics`,
+    cals[year].toString()
+));
+


### PR DESCRIPTION
Add a build script to generate ICS files (one per year) at build time containing all events.

To test it : 

```shell
cd page
npm install -D --force

cd ../tools
node mdValidator.js
node mdParser.js
node generateIcs.js

cd ../page
npm run build

cd build
cp ../src/misc/*.ics .
npx serve
```

Note : I don't know React enough to make generated ICS files work in development mode (as it is located in a different folder), however, it seems to be working when building production assets, as described above. If you have any hints on what is missing, I'd appreciate some feedback :) 