### PR TITLE
Add T-DOSE 2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ All the data (past and coming) is available publicly in JSON:
 
 ### June
 
+* 1-2: [T-DOSE](https://t-dose.org/2024/) - Geldrop (The Netherlands)
 * 12-14: [RenderATL](https://www.renderatl.com/) - Atlanta, GA (USA)
 * 20-21: [Voxxed Days Luxembourg](https://luxembourg.voxxeddays.com/en/) - Grand-Duchy of Luxembourg (Luxembourg)
 


### PR DESCRIPTION
T-DOSE is a freely accessible open source event in the south of the Netherlands (Geldrop, near Eindhoven).