### PR TITLE
feat: add event cont for day, month and year

### DIFF
--- a/page/src/App.jsx
+++ b/page/src/App.jsx
@@ -12,15 +12,9 @@ import 'misc/fonts/inter/inter.css';
 import 'styles/App.css';
 import {hasEvents} from "./utils";
 
-const EventCount = ({allEvents}) => {
-  <div>
-    {allEvents.length}
-  </div>
-}
 const App = () => {
   const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
   const [userState, userDispatch] = useReducer(reducer, {date: null, month: null, year: null});
-  // const [eventState, setEventState]
   const providerState = {
     userState,
     userDispatch,

--- a/page/src/App.jsx
+++ b/page/src/App.jsx
@@ -12,9 +12,15 @@ import 'misc/fonts/inter/inter.css';
 import 'styles/App.css';
 import {hasEvents} from "./utils";
 
+const EventCount = ({allEvents}) => {
+  <div>
+    {allEvents.length}
+  </div>
+}
 const App = () => {
   const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
   const [userState, userDispatch] = useReducer(reducer, {date: null, month: null, year: null});
+  // const [eventState, setEventState]
   const providerState = {
     userState,
     userDispatch,

--- a/page/src/components/EventCount/EventCount.jsx
+++ b/page/src/components/EventCount/EventCount.jsx
@@ -1,12 +1,10 @@
 const getCountText = (count) => {
-    console.log(`count: ${count}`);
     if (typeof count === 'undefined' || count === 0) return 'no event'
     if (count === 1) return '1 event'
     return `${count} events`
 }
 
 const EventCount = ({events}) => {
-    console.log(`events: ${events}`);
     return (<p className='eventCount'>{getCountText(events.length)}</p>)
 }
 export default EventCount;

--- a/page/src/components/EventCount/EventCount.jsx
+++ b/page/src/components/EventCount/EventCount.jsx
@@ -1,7 +1,11 @@
 const getCountText = (count) => {
-    if (typeof count === 'undefined' || count === 0) return 'no event'
-    if (count === 1) return '1 event'
-    return `${count} events`
+    const getCountText = (count) => {
+        if (count) {
+          const plural = count > 1 ? "s" : ""
+          return `${count} event${plural}`;
+        }
+        return "no event";
+      };
 }
 
 const EventCount = ({events}) => {

--- a/page/src/components/EventCount/EventCount.jsx
+++ b/page/src/components/EventCount/EventCount.jsx
@@ -1,0 +1,12 @@
+const getCountText = (count) => {
+    console.log(`count: ${count}`);
+    if (typeof count === 'undefined' || count === 0) return 'no event'
+    if (count === 1) return '1 event'
+    return `${count} events`
+}
+
+const EventCount = ({events}) => {
+    console.log(`events: ${events}`);
+    return (<p className='eventCount'>{getCountText(events.length)}</p>)
+}
+export default EventCount;

--- a/page/src/components/EventCount/EventCount.jsx
+++ b/page/src/components/EventCount/EventCount.jsx
@@ -1,14 +1,12 @@
-const getCountText = (count) => {
-    const getCountText = (count) => {
-        if (count) {
-          const plural = count > 1 ? "s" : ""
-          return `${count} event${plural}`;
-        }
-        return "no event";
-      };
-}
+const getCountText = count => {
+  if (count) {
+    const plural = count > 1 ? 's' : '';
+    return `${count} event${plural}`;
+  }
+  return 'no event';
+};
 
 const EventCount = ({events}) => {
-    return (<p className='eventCount'>{getCountText(events.length)}</p>)
-}
+  return <p className="eventCount">{getCountText(events.length)}</p>;
+};
 export default EventCount;

--- a/page/src/components/SelectedEvents/SelectedEvents.jsx
+++ b/page/src/components/SelectedEvents/SelectedEvents.jsx
@@ -2,6 +2,7 @@ import {useMemo, useRef, useState} from 'react';
 
 import 'styles/SelectedEvents.css';
 import EventDisplay from '../EventDisplay/EventDisplay';
+import EventCount from '../EventCount/EventCount'
 import {formatDate, getMonthName} from '../../utils';
 import {useCustomContext} from 'app.context';
 import { ArrowLeftCircle, ArrowRightCircle } from 'lucide-react';
@@ -97,7 +98,8 @@ const SelectedEvents = ({year, month, date}) => {
             {previous}
             <span>{getMonthName(month) || formatDate(date)}</span>
             {next}
-          </h3>
+            </h3>
+            <EventCount events={events} />
           <div className="eventsGridDisplay">{events}</div>
         </>
       ) : (

--- a/page/src/components/YearSelector/YearSelector.jsx
+++ b/page/src/components/YearSelector/YearSelector.jsx
@@ -8,7 +8,6 @@ import { getYearEvents } from 'utils';
 import EventCount from 'components/EventCount/EventCount';
 
 const YearSelector = ({ year, onChange }) => {
-  console.log(`year: ${year}`);
   return (
     <div>
       <div className="yearNavigator">

--- a/page/src/components/YearSelector/YearSelector.jsx
+++ b/page/src/components/YearSelector/YearSelector.jsx
@@ -4,13 +4,22 @@ import { ArrowLeftCircle, ArrowRightCircle } from 'lucide-react';
 
 
 import 'styles/YearSelector.css';
+import { getYearEvents } from 'utils';
+import EventCount from 'components/EventCount/EventCount';
 
-const YearSelector = ({year, onChange}) => {
+const YearSelector = ({ year, onChange }) => {
+  console.log(`year: ${year}`);
   return (
-    <div className="yearNavigator">
-      <ArrowLeftCircle onClick={() => onChange(year - 1)} />
-      <h2 className="bigYearLabel">{year}</h2>
-      <ArrowRightCircle onClick={() => onChange(year + 1)} />
+    <div>
+      <div className="yearNavigator">
+        <ArrowLeftCircle onClick={() => onChange(year - 1)} />
+        <h2 className="bigYearLabel">{year}</h2>
+        <ArrowRightCircle onClick={() => onChange(year + 1)} />
+
+      </div>
+      <div>
+        <EventCount events={getYearEvents(year)} />
+      </div>
     </div>
   );
 };

--- a/page/src/styles/SelectedEvents.css
+++ b/page/src/styles/SelectedEvents.css
@@ -20,3 +20,8 @@
 .eventDateDisplay span {
   padding: 0 1rem;
 }
+
+.eventCount {
+  text-align: center;
+  font-weight: normal;
+}

--- a/page/src/utils.js
+++ b/page/src/utils.js
@@ -30,6 +30,12 @@ export const getEventsByYear = () => {
   window.dev_events = events;
 };
 
+export const getYearEvents = (year) => {
+  const events = allEvents.filter(e => new Date(e.date[0]).getFullYear() === year)
+
+  return events
+}
+
 export const hasEvents = (year) => Boolean(allEvents.find(e => new Date(e.date[0]).getFullYear() === year))
 
 const lpad2 = number => ('0' + number).slice(-2);


### PR DESCRIPTION
Result of contributing session with @Farsen976 

* Added a `<EventCount />` component that take a list of events
  * adjust label to 0, 1 or more events
* Updated `<SelectedEvents>` and `<YearSelector>` to use `<EventCount/>`

[event count.webm](https://github.com/scraly/developers-conferences-agenda/assets/1212392/2262973f-cf6c-40f0-a8c2-b2ee117a06cf)
