### PR TITLE
provide JSON and ATOM rss feeds

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -24,9 +24,11 @@ jobs:
       - name: Parse Markdowns
         working-directory: tools
         run: |
+          npm install -D
           node mdValidator.js
           node mdParser.js
           node generateIcs.js
+          node generateRSS.js
       - working-directory: page
         run: npm run build
       - name: Make all-*.json files available at the site root
@@ -35,6 +37,7 @@ jobs:
           mv ../page/src/misc/all-events.json ../page/build/all-events.json
           mv ../page/src/misc/all-cfps.json ../page/build/all-cfps.json
           mv ../page/src/misc/*.ics ../page/build/
+          mv ../page/src/misc/feed-events.* ../page/build/
       - name: Deploy to GitHub Pages
         if: github.ref_name == 'main'
         uses: crazy-max/ghaction-github-pages@v2

--- a/page/.gitignore
+++ b/page/.gitignore
@@ -26,3 +26,4 @@ yarn-error.log*
 all-events.json
 all-cfps.json
 developer-conference-*.ics
+feed-events.*

--- a/page/index.html
+++ b/page/index.html
@@ -63,6 +63,12 @@
           <li><a href="https://developers.events/all-cfps.json" target="_blank" class="footer"
             >Full CFPs list</a
           ></li>
+          <li><a href="https://developers.events/feed-events.xml" target="_blank" class="footer"
+            >ATOM feed</a
+          ></li>
+          <li><a href="https://developers.events/feed-events.json" target="_blank" class="footer"
+            >JSON feed</a
+          ></li>
         </ul>
       </p>
     </div>

--- a/run.sh
+++ b/run.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
 
-# This script can be runed locally in order to set up and run the website for development purpose
+# This script can be ran locally in order to set up and run the website for development purpose
 
 cd page
 npm install -D
 
 cd ../tools
+npm install -D
 node mdValidator.js
 node mdParser.js
 node generateIcs.js
+node generateRSS.js
 
 cd ../page
 npm start

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,1 +1,20 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 *.json
+!package.json
+!package-lock.json
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# misc
+.DS_Store
+.env.local
+.env.*.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+*~

--- a/tools/generateRSS.js
+++ b/tools/generateRSS.js
@@ -1,0 +1,34 @@
+const feed = require("feed");
+const fs = require("fs");
+
+const ROOT = "../";
+const ATOM_OUTPUT = ROOT + "page/src/misc/feed-events.xml";
+const JSON_OUTPUT = ROOT + "page/src/misc/feed-events.json";
+
+const today = Date.now()
+
+const f = new feed.Feed({
+  title: "Developer Conferences Agenda",
+  description: "A list of tech conferences's date and CFP in order to help conferences organizers, speakers & attendees",
+  id: "https://developers.events/",
+  link: "https://developers.events/",
+  feedLinks: {
+    json: "https://developers.events/feed-events.json",
+    atom: "https://developers.events/feed-events.atom"
+  },
+});
+
+events = JSON.parse(fs.readFileSync('../page/src/misc/all-events.json'), 'utf-8');
+events.forEach(event => {
+  f.addItem({
+    title: event.name,
+    id: event.hyperlink,
+    link: event.hyperlink,
+    description: event.name,
+    content: event.name + " @ " + event.location + " - " + new Date(event.date[0]),
+    date: new Date(today),
+  })
+})
+
+fs.writeFileSync(ATOM_OUTPUT, f.atom1());
+fs.writeFileSync(JSON_OUTPUT, f.json1());

--- a/tools/package-lock.json
+++ b/tools/package-lock.json
@@ -1,0 +1,42 @@
+{
+  "name": "tools",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tools",
+      "version": "0.1.0",
+      "dependencies": {
+        "feed": "^4.2.2"
+      }
+    },
+    "node_modules/feed": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/feed/-/feed-4.2.2.tgz",
+      "integrity": "sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==",
+      "dependencies": {
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
+      }
+    }
+  }
+}

--- a/tools/package.json
+++ b/tools/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "tools",
+  "version": "0.1.0",
+  "private": true,
+  "type": "commonjs",
+  "dependencies": {
+    "feed": "^4.2.2"
+  }
+}


### PR DESCRIPTION
Hi,

In this PR, we add RSS support to the agenda. It allows users to subscribe to the RSS feed from a RSS client (Slack, browser extension, etc.) using this URL: https://developers.events/feed-events.xml

Feed is generated in the CI from the `all-events.json` list previously generated. While I locally tested the feed generation + reading from a local client, I did not tested the CI part.