### PR TITLE
adding 90daysofdevops event

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ All the data (past and coming) is available publicly in JSON:
 
 ### January
 
+* 1-31/03: [90DaysOfDevOps](https://github.com/MichaelCade/90DaysOfDevOps) - Online <a href="https://sessionize.com/90daysofdevops-2024-community-edition/"><img alt="CFP 90DaysOfDevOps" src="https://img.shields.io/static/v1?label=CFP&message=until%2002-November-2023&color=green"></a>
 * 8-11: [NDC Security](https://ndc-security.com/) - Oslo (Norway)
 * 20: [Voxxed Days Ticino](https://voxxeddays.com/ticino/) - Lugano (Switzerland)
 * 24-25: [KCD Oslo](https://community.cncf.io/events/details/cncf-kcd-norway-presents-kcd-oslo-2024/) - Oslo (Norway)


### PR DESCRIPTION
We have 30 days left for CFPs

An online event hosted on YouTube for the community by the community, we have some great sessions submitted so far. 