### PR TITLE
Makes conferences looking like a fullday event

### DIFF
--- a/tools/generateIcs.js
+++ b/tools/generateIcs.js
@@ -4,6 +4,16 @@ const { VCALENDAR, VEVENT } = require('../page/node_modules/ics-js');
 const allEvents = JSON.parse(fs.readFileSync('../page/src/misc/all-events.json'), 'utf-8');
 const cals = {};
 
+function formatDate(date = new Date()) {
+    const year = date.toLocaleString('default', {year: 'numeric'});
+    const month = date.toLocaleString('default', {
+      month: '2-digit',
+    });
+    const day = date.toLocaleString('default', {day: '2-digit'});
+  
+    return [year, month, day].join('');
+}
+
 for (const event of allEvents) {
     let eventYear = new Date(event.date[0]).getFullYear();
     if (!cals[eventYear]) {
@@ -14,9 +24,9 @@ for (const event of allEvents) {
     let vevent = new VEVENT();
     vevent.addProp('UID', `${event.name}@dca-${eventYear}`);
     vevent.addProp('DTSTAMP', new Date());
-    vevent.addProp('DTSTART', new Date(event.date[0]));
+    vevent.addProp('DTSTART', formatDate(new Date(event.date[0])));
     if(event.date[1]) {
-        vevent.addProp('DTEND', new Date(event.date[1]));
+        vevent.addProp('DTEND', formatDate(new Date(event.date[1])));
     }
     vevent.addProp('LOCATION', event.location || 'unspecified');
     vevent.addProp('SUMMARY', event.name);


### PR DESCRIPTION
Instead of having a 24H event when you import in your calendar (which is ugly),
we can have full day event instead.

It now looks like this:

![image](https://github.com/scraly/developers-conferences-agenda/assets/274222/2ba568bc-68f7-4096-a771-4551fbf03387)
