### PR TITLE
Add generateIcs4OpenedCfps.js

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -10,6 +10,7 @@ npm install -D
 node mdValidator.js
 node mdParser.js
 node generateIcs.js
+node generateIcs4OpenedCfps.js
 node generateRSS.js
 
 cd ../page

--- a/tools/README.md
+++ b/tools/README.md
@@ -42,3 +42,37 @@ outputFile whose value is "-" are going to stdout.
  - [x] ~~Localized symbols may interfere with parser. (e.g. JavaOne @ 2022.md)~~
  - [x] ~~No `:` after schedule date interefere with parser. (e.g. Voxxed Melbourne @ 2019.md)~~
 
+## generateIcs4OpenedCfps.js
+
+### Mission
+
+Reads the `page/src/misc/all-cfps.json` file and generates a `developer-conference-opened-cfps.ics` file. People can then subscribe to https://developers.events/developer-conference-opened-cfps.ics to know when CFPs are closing.
+
+Note that the generated calendar only includes CFPs which are not yet closed when the script is running.
+
+### Usage
+
+```sh
+node generateIcs4OpenedCfps.js  
+```
+
+### Output format
+
+```ics
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:DCA
+BEGIN:VEVENT
+UID:DevFest Jalingo 2023@dca-2023
+DTSTAMP:20231019T114828
+DTSTART:20231020
+LOCATION:Jalingo (Nigeria)
+SUMMARY:DevFest Jalingo 2023
+URL:https://sessionize.com/devfest-2023-jalingo/
+END:VEVENT
+END:VCALENDAR
+```
+
+### Known Issues
+
+Not yet 😉

--- a/tools/generateIcs4OpenedCfps.js
+++ b/tools/generateIcs4OpenedCfps.js
@@ -1,0 +1,39 @@
+const fs = require("fs");
+const { VCALENDAR, VEVENT } = require('../page/node_modules/ics-js/dist/ics-js');
+
+const allEvents = JSON.parse(fs.readFileSync('../page/src/misc/all-cfps.json'), 'utf-8');
+const cfpCal = new VCALENDAR();
+cfpCal.addProp('VERSION', 2);
+cfpCal.addProp('PRODID', 'DCA');
+const runDate = new Date();
+
+function formatDate(date = new Date()) {
+    const year = date.toLocaleString('default', {year: 'numeric'});
+    const month = date.toLocaleString('default', {
+      month: '2-digit',
+    });
+    const day = date.toLocaleString('default', {day: '2-digit'});
+  
+    return [year, month, day].join('');
+}
+
+for (const event of allEvents) {
+    let cfpClosingDate = new Date(event.untilDate);
+    if (cfpClosingDate.getTime() > runDate.getTime()) {
+        let eventYear = new Date(event.conf.date[0]).getFullYear();
+        let vevent = new VEVENT();
+        vevent.addProp('UID', `${event.conf.name}@dca-${eventYear}`);
+        vevent.addProp('DTSTAMP', new Date());
+        vevent.addProp('DTSTART', formatDate(cfpClosingDate));
+        vevent.addProp('LOCATION', event.conf.location || 'unspecified');
+        vevent.addProp('SUMMARY', event.conf.name);
+        vevent.addProp('URL', event.link || event.conf.hyperlink || 'unspecified');
+        cfpCal.addComponent(vevent);
+    }
+}
+
+// Write the opened cfps calendar file
+fs.writeFileSync(
+    `../page/src/misc/developer-conference-opened-cfps.ics`,
+    cfpCal.toString()
+);


### PR DESCRIPTION
## Mission

Reads the `page/src/misc/all-cfps.json` file and generates a `developer-conference-opened-cfps.ics` file. People can then subscribe to https://developers.events/developer-conference-opened-cfps.ics to know when CFPs are closing.

Note that the generated calendar only includes CFPs which are not yet closed when the script is running.

## Usage

```sh
node generateIcs4OpenedCfps.js
```

## Output format

```ics
BEGIN:VCALENDAR
VERSION:2.0
PRODID:DCA
BEGIN:VEVENT
UID:DevFest Jalingo 2023@dca-2023
DTSTAMP:20231019T114828
DTSTART:20231020
LOCATION:Jalingo (Nigeria)
SUMMARY:DevFest Jalingo 2023
URL:https://sessionize.com/devfest-2023-jalingo/
END:VEVENT
END:VCALENDAR
```

## Known Issues

Not yet 😉

## Screenshot after importing the ICS calendar

<img width="1237" alt="image" src="https://github.com/scraly/developers-conferences-agenda/assets/274222/cdbeb471-8cb3-4216-95de-100d36b813d3">
