### PR TITLE
Generate the goelocations files in a more readable format

### DIFF
--- a/page/src/misc/geolocations.json
+++ b/page/src/misc/geolocations.json
@@ -1,1 +1,1570 @@
-{"Aarhus (Denmark)":{"latitude":56.1496278,"longitude":10.2134046},"Abuja (Nigeria)":{"latitude":9.0643305,"longitude":7.4892974},"Accra (Ghana)":{"latitude":5.5571096,"longitude":-0.2012376},"Ado (Nigeria)":{"latitude":6.6,"longitude":2.933333},"Agadir (Morocco)":{"latitude":30.4205162,"longitude":-9.5838532},"Ahmedabad (India)":{"latitude":23.0216238,"longitude":72.5797068},"Aix-en-Provence (France)":{"latitude":43.5298424,"longitude":5.4474738},"Alberta (Canada)":{"latitude":55.001251,"longitude":-115.002136},"Amboise (France)":{"latitude":47.4110351,"longitude":0.983698},"Amsterdam (Netherlands)":{"latitude":52.3730796,"longitude":4.8924534},"Anglet (France)":{"latitude":43.4813927,"longitude":-1.5149935},"Antalya (Turkey)":{"latitude":36.8872942,"longitude":30.7074549},"Antwerp (Belgium)":{"latitude":51.2211097,"longitude":4.3997081},"Athens (Greece)":{"latitude":37.9755648,"longitude":23.7348324},"Atlanta (USA)":{"latitude":33.7489924,"longitude":-84.3902644},"Atlanta, GA (USA)":{"latitude":33.7489924,"longitude":-84.3902644},"Aurora, Colorado (USA)":{"latitude":39.7405111,"longitude":-104.830994},"Austin (USA)":{"latitude":30.2711286,"longitude":-97.7436995},"Austin, TX (USA)":{"latitude":30.2711286,"longitude":-97.7436995},"Australia":{"latitude":-24.7761086,"longitude":134.755},"Austria":{"latitude":36.9148511,"longitude":-4.7534501},"Avignon (France)":{"latitude":43.9492493,"longitude":4.8059012},"Baden (France)":{"latitude":47.6199988,"longitude":-2.9184744},"Bali (Indonesia)":{"latitude":-8.456018100000001,"longitude":115.27038551191185},"Baltimore (USA)":{"latitude":39.2908816,"longitude":-76.610759},"Bangkok (Thailand)":{"latitude":13.8245796,"longitude":100.6224463},"Banjul (Gambia)":{"latitude":13.4410165,"longitude":-16.56275092072591},"Barcelona (Spain)":{"latitude":41.3828939,"longitude":2.1774322},"Basel (Switzerland)":{"latitude":47.5581077,"longitude":7.5878261},"Beirut (Lebanon)":{"latitude":33.8959203,"longitude":35.47843},"Belarus":{"latitude":47.69245275,"longitude":19.797755868882057},"Belem (Brazil)":{"latitude":-1.45056,"longitude":-48.4682453},"Belfast (UK)":{"latitude":54.596391,"longitude":-5.9301829},"Belgium":{"latitude":50.6402809,"longitude":4.6667145},"Belgrade (Serbia)":{"latitude":44.8178131,"longitude":20.4568974},"Bellevue, WA (USA)":{"latitude":47.6144219,"longitude":-122.192337},"Bengaluru (India)":{"latitude":12.9767936,"longitude":77.590082},"Bengaluru, Karnataka (India)":{"latitude":12.9767936,"longitude":77.590082},"Berlin (Germany)":{"latitude":52.5170365,"longitude":13.3888599},"Bern (Switzerland)":{"latitude":46.9484742,"longitude":7.4521749},"Beurs van Berlage (Netherlands)":{"latitude":52.3750218,"longitude":4.89626468097017},"Bilbao (Spain)":{"latitude":43.2630018,"longitude":-2.9350039},"Birmingham (UK)":{"latitude":52.4796992,"longitude":-1.9026911},"Birmingham (USA)":{"latitude":33.5206824,"longitude":-86.8024326},"Bochum (Germany)":{"latitude":51.4818111,"longitude":7.2196635},"Boise (USA)":{"latitude":43.6166163,"longitude":-116.200886},"Bologna (Italy)":{"latitude":44.4938203,"longitude":11.3426327},"Bordeaux (France)":{"latitude":44.841225,"longitude":-0.5800364},"Boston, Massachusetts (USA)":{"latitude":42.3554334,"longitude":-71.060511},"Boulder CA (USA)":{"latitude":33.615491899999995,"longitude":-117.39528100998477},"Brabrand (Denmark)":{"latitude":56.1565872,"longitude":10.1056465},"Brescia (Italy)":{"latitude":45.77958045,"longitude":10.4258729694612},"Brest (France)":{"latitude":48.3905283,"longitude":-4.4860088},"Bristol (UK)":{"latitude":51.4538022,"longitude":-2.5972985},"Brno (Czech Republic)":{"latitude":49.1922443,"longitude":16.6113382},"Broomfield, CO (USA)":{"latitude":39.9403995,"longitude":-105.05208},"Brussels (Belgium)":{"latitude":50.8550018,"longitude":4.3512333761166175},"Brühl (Germany)":{"latitude":50.8291313,"longitude":6.9037057},"Bucharest (Romania)":{"latitude":44.4361414,"longitude":26.1027202},"Budapest (Hungary)":{"latitude":47.4978918,"longitude":19.0401609},"Bujumbura (Burundi)":{"latitude":-3.3638125,"longitude":29.3675028},"Bulgaria":{"latitude":46.7889169,"longitude":23.6184909},"Bydgoszcz (Poland)":{"latitude":53.12974625,"longitude":18.029369658534854},"Caceres (Spain)":{"latitude":39.759172500000005,"longitude":-6.1379457147709005},"Cairo (Egypt)":{"latitude":30.0443879,"longitude":31.2357257},"California (USA)":{"latitude":36.7014631,"longitude":-118.755997},"Canada":{"latitude":61.0666922,"longitude":-107.991707},"Cannes (France)":{"latitude":43.5515198,"longitude":7.0134418},"Cape Town (South Africa)":{"latitude":-33.928992,"longitude":18.417396},"Cardiff (Wales)":{"latitude":51.4816546,"longitude":-3.1791934},"Chambéry (France)":{"latitude":45.5662672,"longitude":5.9203636},"Charlotte, North Carolina (USA)":{"latitude":35.2272086,"longitude":-80.8430827},"Charlottesville, VA (USA)":{"latitude":38.029306,"longitude":-78.4766781},"Chattanooga (USA)":{"latitude":35.0457219,"longitude":-85.3094883},"Chemnitz (Germany)":{"latitude":50.8323531,"longitude":12.918914},"Chennai (India)":{"latitude":13.0836939,"longitude":80.270186},"Cheverny in the Châteaux of the Loire Valley (France)":{"latitude":47.49973,"longitude":1.46013},"Chicago (USA)":{"latitude":41.8755616,"longitude":-87.6244212},"Chicago (United States)":{"latitude":41.8755616,"longitude":-87.6244212},"Chicago, Illinois (USA)":{"latitude":41.8755616,"longitude":-87.6244212},"Chile":{"latitude":-31.7613365,"longitude":-71.3187697},"Choisy-le-Roi (France)":{"latitude":48.7630238,"longitude":2.4093664},"Christchurch (New Zealand)":{"latitude":-43.530955,"longitude":172.6364343},"Château de Massillan’ - Drome (France)":{"latitude":44.2330208,"longitude":4.793006999999999},"Cilacap, Jawa Tengah (Indonesia)":{"latitude":-7.46167105,"longitude":108.80461463117007},"Clermont Ferrand (France)":{"latitude":45.7774551,"longitude":3.0819427},"Clermont-Ferrand (France)":{"latitude":45.7774551,"longitude":3.0819427},"Cleveland (USA)":{"latitude":41.4996574,"longitude":-81.6936772},"Cluj, Transylvania (Romania)":{"latitude":46.7712101,"longitude":23.6236353},"Cluj-Napoca (Romania)":{"latitude":46.769379,"longitude":23.5899542},"Coimbra (Portugal)":{"latitude":40.2111931,"longitude":-8.4294632},"Colombo (Sri Lanka)":{"latitude":6.9388614,"longitude":79.8542005},"Copenhagen (Denmark)":{"latitude":55.6867243,"longitude":12.5700724},"Copenhaguen (Denmark)":{"latitude":55.6867243,"longitude":12.5700724},"Copiapó (Chile)":{"latitude":-27.3664685,"longitude":-70.3322753},"Cracow (Poland)":{"latitude":50.0606452,"longitude":19.9370985},"Craiova (Romania)":{"latitude":44.3190159,"longitude":23.7965614},"Crete (Greece)":{"latitude":35.308495199999996,"longitude":24.46334231842296},"Croatia":{"latitude":45.3658443,"longitude":15.6575209},"Czech Republic":{"latitude":49.7439047,"longitude":15.3381061},"Dakar (Senegal)":{"latitude":14.693425,"longitude":-17.447938},"Dallas/Irving, Texas (USA)":{"latitude":32.891402049999996,"longitude":-96.97086265455442},"Darmstadt (Germany)":{"latitude":49.8851869,"longitude":8.6736295},"Denmark":{"latitude":55.670249,"longitude":10.3333283},"Denver (USA)":{"latitude":39.7392364,"longitude":-104.984862},"Detroit (USA)":{"latitude":42.3315509,"longitude":-83.0466403},"Dhaka (Bangladesh)":{"latitude":23.7644025,"longitude":90.389015},"Dijon (France)":{"latitude":47.3215806,"longitude":5.0414701},"Dinan (France)":{"latitude":48.4539775,"longitude":-2.047687},"Dresden (Germany)":{"latitude":51.0493286,"longitude":13.7381437},"Dubai":{"latitude":2.9470179,"longitude":30.961206},"Dubai (United Arab Emirates)":{"latitude":25.2653471,"longitude":55.2924914},"Dublin (Ireland)":{"latitude":53.3493795,"longitude":-6.2605593},"Durham, NC (USA)":{"latitude":35.996653,"longitude":-78.9018053},"Dusseldorf (Germany)":{"latitude":51.2254018,"longitude":6.7763137},"Düsseldorf (Germany)":{"latitude":51.2254018,"longitude":6.7763137},"Ede (Netherlands)":{"latitude":52.07168255,"longitude":5.745510631034939},"Edinburgh (Scotland)":{"latitude":55.9533456,"longitude":-3.1883749},"Faenza (Italy)":{"latitude":44.2855555,"longitude":11.8832055},"Faro (Portugal)":{"latitude":37.0162727,"longitude":-7.9351771},"Firenze (Italy)":{"latitude":43.7698712,"longitude":11.2555757},"Florence (Italy)":{"latitude":43.7698712,"longitude":11.2555757},"Florianópolis (Brazil)":{"latitude":-27.5973002,"longitude":-48.5496098},"Florida (USA)":{"latitude":27.7567667,"longitude":-81.4639835},"France":{"latitude":46.603354,"longitude":1.8883335},"Frankfurt (Germany)":{"latitude":50.1106444,"longitude":8.6820917},"Gardanne (France)":{"latitude":43.455613,"longitude":5.4710661},"Gdansk (Poland)":{"latitude":54.3706858,"longitude":18.61298210330077},"Geldrop (Netherlands)":{"latitude":51.4226684,"longitude":5.5607546},"Geneva (Switzerland)":{"latitude":46.2017559,"longitude":6.1466014},"Genève (Switzerland)":{"latitude":46.2017559,"longitude":6.1466014},"Germany":{"latitude":34.895926,"longitude":-83.4665496},"Ghent (Belgium)":{"latitude":51.0538286,"longitude":3.7250121},"Glasgow (Scotland)":{"latitude":55.861155,"longitude":-4.2501687},"Goa (India)":{"latitude":15.3004543,"longitude":74.0855134},"Goiana (Brazil)":{"latitude":-7.560603,"longitude":-34.99591},"Golfe du morbihan (France)":{"latitude":47.5976972,"longitude":-2.7533397586005415},"Grand Rapids, Michigan (USA)":{"latitude":42.9632425,"longitude":-85.6678639},"Grand-Duchy of Luxembourg (Luxembourg)":{"latitude":49.6112768,"longitude":6.129799},"Grenoble (France)":{"latitude":45.1875602,"longitude":5.7357819},"Guadalajara (Mexico)":{"latitude":20.6720375,"longitude":-103.338396},"Gujarat (India)":{"latitude":22.3850051,"longitude":71.745261},"Hamburg (Germany)":{"latitude":53.550341,"longitude":10.000654},"Hannover (Germany)":{"latitude":52.3744779,"longitude":9.7385532},"Harare (Zimbabwe)":{"latitude":-17.8567035,"longitude":31.0601584},"Hawai (USA)":{"latitude":19.593801499999998,"longitude":-155.42837009716908},"Helsinki (Finland)":{"latitude":60.1674881,"longitude":24.9427473},"Ho chi Minh (Vietnam)":{"latitude":10.7763897,"longitude":106.7011391},"Hollywood (USA)":{"latitude":34.0980031,"longitude":-118.329523},"Hong Kong":{"latitude":22.2793278,"longitude":114.1628131},"Honolulu, Hawai (USA)":{"latitude":21.2891309,"longitude":-157.7173915},"Hotel New York - The Art of Marvel, Disneyland Paris (France)":{"latitude":48.8707602,"longitude":2.7877176},"Iasi (Romania)":{"latitude":47.1615416,"longitude":27.5837224},"Iceland":{"latitude":64.9841821,"longitude":-18.1059013},"Ikorodu (Nigeria)":{"latitude":6.6191233,"longitude":3.5041271},"Illinois (USA)":{"latitude":40.0796606,"longitude":-89.4337288},"India":{"latitude":22.3511148,"longitude":78.6677428},"Indianapolis (USA)":{"latitude":39.7683331,"longitude":-86.1583502},"Ipswich (UK)":{"latitude":52.0579324,"longitude":1.1528095},"Ireland":{"latitude":52.865196,"longitude":-7.9794599},"Islamabad (Pakistan)":{"latitude":33.6938118,"longitude":73.0651511},"Islas Canarias (España)":{"latitude":28.2935785,"longitude":-16.621447121144122},"Istanbul (Turkey)":{"latitude":41.0091982,"longitude":28.9662187},"Jakarta (Indonesia)":{"latitude":-6.175247,"longitude":106.8270488},"Jalingo (Nigeria)":{"latitude":8.8945377,"longitude":11.3644261},"Japan":{"latitude":40.9921996,"longitude":-75.9078749},"Jinja (Uganda)":{"latitude":0.57515665,"longitude":33.28052985775423},"Johannesburg (South Africa)":{"latitude":-26.205,"longitude":28.049722},"Kampala (Uganda)":{"latitude":0.3177137,"longitude":32.5813539},"Kathmandu (Nepal)":{"latitude":27.708317,"longitude":85.3205817},"Kenya":{"latitude":1.4419683,"longitude":38.4313975},"Kiev (Ukraine)":{"latitude":50.4500336,"longitude":30.5241361},"Kigali (Rwanda)":{"latitude":-1.950851,"longitude":30.061507},"Kilkenny (Ireland)":{"latitude":52.5687098,"longitude":-7.188983092181514},"Kitwe (Zambia)":{"latitude":-12.8104186,"longitude":28.2068361},"Kolkata (India)":{"latitude":22.5726459,"longitude":88.3638953},"Kongsberg (Norway)":{"latitude":59.594550049999995,"longitude":9.670860075643745},"Krakow (Croatia)":{"latitude":45.5584831,"longitude":18.682409},"Krakow (Poland)":{"latitude":50.0619474,"longitude":19.9368564},"Kraków (Poland)":{"latitude":50.0619474,"longitude":19.9368564},"Kyiv (Ukraine)":{"latitude":50.4500336,"longitude":30.5241361},"L'aquila (Italy)":{"latitude":42.1368853,"longitude":13.610341022538911},"La Ciotat (France)":{"latitude":43.1758591,"longitude":5.6062495},"La Paz (Bolivia)":{"latitude":-16.4955455,"longitude":-68.1336229},"La Rochelle (France)":{"latitude":46.1591126,"longitude":-1.1520434},"Lagos (Nigeria)":{"latitude":6.4550575,"longitude":3.3941795},"Lake Tahoe (USA)":{"latitude":39.08854049999999,"longitude":-120.05035277301698},"Las Vegas (USA)":{"latitude":36.1672559,"longitude":-115.148516},"Las Vegas, NV (USA)":{"latitude":36.1672559,"longitude":-115.148516},"Las Vegas, Nevada (USA)":{"latitude":36.1672559,"longitude":-115.148516},"Lausanne (Switzerland)":{"latitude":46.5218269,"longitude":6.6327025},"Le Mans (France)":{"latitude":48.0073849,"longitude":0.1967849},"Lehi, UTAH (USA)":{"latitude":40.3881114,"longitude":-111.8486019},"Lille & Lyon (France)":{"latitude":45.6919466,"longitude":4.5946695},"Lille (France)":{"latitude":50.6365654,"longitude":3.0635282},"Lille Grand Palais (France)":{"latitude":50.6296509,"longitude":3.0749235},"Lille, Lyon, Nantes, Tours (France)":{"latitude":50.62925,"longitude":3.057256},"Lima (Peru)":{"latitude":-12.0621065,"longitude":-77.0365256},"Linz (Austria)":{"latitude":48.3059078,"longitude":14.286198},"Lisbon (Portugal)":{"latitude":38.7077507,"longitude":-9.1365919},"Ljubljana (Slovenia)":{"latitude":46.0500268,"longitude":14.5069289},"Lokoja (Nigeria)":{"latitude":7.802355,"longitude":6.7430327},"London (UK)":{"latitude":51.5073359,"longitude":-0.12765},"Los Angeles (USA)":{"latitude":34.0536909,"longitude":-118.242766},"Los Angeles Convention Center (USA)":{"latitude":34.0414713,"longitude":-118.26898072389606},"Louvain-La-Neuve (Belgium)":{"latitude":50.6682012,"longitude":4.6128839},"Luanda (Angola)":{"latitude":-8.8272699,"longitude":13.2439512},"Ludwigsburg (Germany)":{"latitude":48.8953937,"longitude":9.1895147},"Lugano (Switzerland)":{"latitude":46.0050102,"longitude":8.9520281},"Luxembourg":{"latitude":49.6112768,"longitude":6.129799},"Lyon (France)":{"latitude":45.7578137,"longitude":4.8320114},"Lyon 3e (France)":{"latitude":45.7541777,"longitude":4.8845249},"MIT (USA)":{"latitude":42.3582529,"longitude":-71.0966272383055},"Madrid (Spain)":{"latitude":40.4167047,"longitude":-3.7035825},"Mainz (Germany)":{"latitude":50.0012314,"longitude":8.2762513},"Malaga (Spain)":{"latitude":36.7213028,"longitude":-4.4216366},"Malmo (Sweden)":{"latitude":55.6052931,"longitude":13.0001566},"Mannheim (Germany)":{"latitude":49.4892913,"longitude":8.4673098},"Marne-la-Vallée (France)":{"latitude":48.8494036,"longitude":2.6727019475243083},"Marseille (France)":{"latitude":43.2961743,"longitude":5.3699525},"Mbarara (Uganda)":{"latitude":-0.4180848,"longitude":30.573737377548046},"Melbourne (Australia)":{"latitude":-37.8142454,"longitude":144.9631732},"Miami (USA)":{"latitude":25.7741728,"longitude":-80.19362},"Milan (Italy)":{"latitude":45.4641943,"longitude":9.1896346},"Milano (Italy)":{"latitude":45.4641943,"longitude":9.1896346},"Minneapolis (USA)":{"latitude":44.9772995,"longitude":-93.2654692},"Minsk (Belarus)":{"latitude":53.9024716,"longitude":27.5618225},"Moka (Mauritius)":{"latitude":-20.2218738,"longitude":57.50275},"Mombasa (Kenya)":{"latitude":-4.05052,"longitude":39.667169},"Mons (Belgium)":{"latitude":50.4549568,"longitude":3.951958},"Mont de Marsan (France)":{"latitude":43.8911318,"longitude":-0.500972},"Monterey (USA)":{"latitude":36.2231079,"longitude":-121.387742},"Monterrey (Mexico)":{"latitude":25.6802019,"longitude":-100.315258},"Montpellier (France)":{"latitude":43.6112422,"longitude":3.8767337},"Montreal (Canada)":{"latitude":45.5031824,"longitude":-73.5698065},"Montrouge (France)":{"latitude":48.8188544,"longitude":2.3194375},"Montréal (Canada)":{"latitude":45.5031824,"longitude":-73.5698065},"Morocco":{"latitude":28.3347722,"longitude":-10.371337908392647},"Moscow (Russia)":{"latitude":55.7505412,"longitude":37.6174782},"Mountain View (USA)":{"latitude":37.3893889,"longitude":-122.0832101},"Mumbai (India)":{"latitude":19.08157715,"longitude":72.88662753964906},"Munchen (Germany)":{"latitude":48.1371079,"longitude":11.5753822},"Munich (Germany)":{"latitude":48.1371079,"longitude":11.5753822},"Murten (Switzerland)":{"latitude":46.9288643,"longitude":7.1163909},"München (Germany)":{"latitude":48.1371079,"longitude":11.5753822},"NYC (USA)":{"latitude":40.7127281,"longitude":-74.0060152},"Nairobi (Kenya)":{"latitude":-1.3026148499999999,"longitude":36.82884201813725},"Nancy (France)":{"latitude":48.6937223,"longitude":6.1834097},"Nantes (France)":{"latitude":47.2186371,"longitude":-1.5541362},"Nashville (USA)":{"latitude":36.1622767,"longitude":-86.7742984},"Nashville, Tennessee (USA)":{"latitude":36.1622767,"longitude":-86.7742984},"National Harbor, Maryland (USA)":{"latitude":38.7831238,"longitude":-77.0128237},"Netherlands":{"latitude":52.2434979,"longitude":5.6343227},"New Orleans, LO (USA)":{"latitude":32.1538186,"longitude":-80.7602671},"New York (USA)":{"latitude":40.7127281,"longitude":-74.0060152},"New York City (USA)":{"latitude":40.7127281,"longitude":-74.0060152},"Nice (France)":{"latitude":43.7009358,"longitude":7.2683912},"Niort (France)":{"latitude":46.3241132,"longitude":-0.4649403},"Nuremberg (Germany)":{"latitude":49.453872,"longitude":11.077298},"Nürburgring (Germany)":{"latitude":50.3309196,"longitude":6.940674171000003},"Omni La Costa Resort & Spa Carlsbad, California (USA)":{"latitude":33.091985449999996,"longitude":-117.26610534145561},"Ondina (El Salvador)":{"latitude":13.794185,"longitude":-88.89653},"Online":{"latitude":43.59047185,"longitude":3.8595132132013186},"Online (France)":{"latitude":43.59047185,"longitude":3.8595132132013186},"Orange (France)":{"latitude":44.1371311,"longitude":4.8078783},"Orlando, Florida (USA)":{"latitude":28.5421109,"longitude":-81.3790304},"Orléans (France)":{"latitude":47.9027336,"longitude":1.9086066},"Oslo (Norway)":{"latitude":59.9133301,"longitude":10.7389701},"Ottawa, Ontario (Canada)":{"latitude":45.4208777,"longitude":-75.6901106},"Owerri (Nigeria)":{"latitude":5.489736,"longitude":7.0341973},"Palo Alto (USA)":{"latitude":37.4443293,"longitude":-122.1598465},"Paris (France)":{"latitude":48.8588897,"longitude":2.3200410217200766},"Paris(France)":{"latitude":48.8588897,"longitude":2.3200410217200766},"Pasadena (USA)":{"latitude":34.1476507,"longitude":-118.1441551},"Perros-Guirec (France)":{"latitude":48.8151133,"longitude":-3.4394662},"Phantasialand near Cologne (Germany)":{"latitude":50.8014727,"longitude":6.8765161},"Philadelphia (USA)":{"latitude":39.9527237,"longitude":-75.1635262},"Phoenix (USA)":{"latitude":33.4484367,"longitude":-112.074141},"Phuket (Thailand)":{"latitude":7.9366015,"longitude":98.3529292},"Plymouth (UK)":{"latitude":50.3712659,"longitude":-4.1425658},"Pointe-Noire (Congo)":{"latitude":-4.8776363,"longitude":11.9748557},"Poitiers (France)":{"latitude":46.5802596,"longitude":0.340196},"Poland":{"latitude":52.215933,"longitude":19.134422},"Portland (USA)":{"latitude":45.5202471,"longitude":-122.674194},"Portland, Maine (USA)":{"latitude":43.6589742,"longitude":-70.2569578},"Portland, OR (USA)":{"latitude":45.5202471,"longitude":-122.674194},"Porto (Portugal)":{"latitude":41.1494512,"longitude":-8.6107884},"Porto Alegre (Brazil)":{"latitude":-30.0324999,"longitude":-51.2303767},"Portorož (Slovenia)":{"latitude":45.5146489,"longitude":13.5910112},"Potsdam (Germany)":{"latitude":52.4009309,"longitude":13.0591397},"Poznan (Poland)":{"latitude":52.4082663,"longitude":16.9335199},"Prague (Czech Republic)":{"latitude":50.0874654,"longitude":14.4212535},"Prizren (Kosovo)":{"latitude":42.2130151,"longitude":20.7363339},"Quebec City (Canada)":{"latitude":46.8137431,"longitude":-71.2084061},"Québec (Canada)":{"latitude":52.4760892,"longitude":-71.8258668},"Raleigh (USA)":{"latitude":35.7803977,"longitude":-78.6390989},"Raleigh, NC (USA)":{"latitude":35.7803977,"longitude":-78.6390989},"Recife (Brazil)":{"latitude":-8.0584933,"longitude":-34.8848193},"Rennes (France)":{"latitude":48.1113387,"longitude":-1.6800198},"Riga (Latvia)":{"latitude":56.9493977,"longitude":24.1051846},"Roma (Italy)":{"latitude":41.8933203,"longitude":12.4829321},"Romania":{"latitude":45.9852129,"longitude":24.6859225},"Rome (Italy)":{"latitude":41.8933203,"longitude":12.4829321},"Roquebrune-sur-Argens (France)":{"latitude":43.4433565,"longitude":6.6363623},"Rotterdam (Netherlands)":{"latitude":51.9244424,"longitude":4.47775},"Rouen (France)":{"latitude":49.4404591,"longitude":1.0939658},"Round Rock (USA)":{"latitude":30.5085915,"longitude":-97.6788056},"Rovinj (Croatia)":{"latitude":45.0807411,"longitude":13.6417282},"Russia":{"latitude":40.2338211,"longitude":-84.4096729},"Région lyonnaise (France)":{"latitude":45.764043,"longitude":4.835659},"SF Bay Area (USA)":{"latitude":37.7749295,"longitude":-122.4194155},"Salt Lake City (USA)":{"latitude":40.7596198,"longitude":-111.886797},"Salt Lake City, Utah (USA)":{"latitude":40.7596198,"longitude":-111.886797},"San Diego (USA)":{"latitude":32.7174202,"longitude":-117.1627728},"San Francisco (USA)":{"latitude":37.7790262,"longitude":-122.419906},"San Francisco, CA (USA)":{"latitude":37.7790262,"longitude":-122.419906},"San Jose (USA)":{"latitude":37.3361663,"longitude":-121.890591},"San Miguel (El Salvador)":{"latitude":13.4803899,"longitude":-88.17722},"Sankt Augustin (Germany)":{"latitude":50.7752776,"longitude":7.1895507},"Santa Clara (USA)":{"latitude":37.2333253,"longitude":-121.6846349},"Santo Domingo (Dominican Republic)":{"latitude":18.4801972,"longitude":-69.942111},"Seattle (USA)":{"latitude":47.6038321,"longitude":-122.330062},"Seattle, Washington (USA)":{"latitude":47.6038321,"longitude":-122.330062},"Seoul (South Korea)":{"latitude":37.5666791,"longitude":126.9782914},"Serbia":{"latitude":44.024322850000004,"longitude":21.07657433209902},"Shangai (China)":{"latitude":31.2312707,"longitude":121.4700152},"Sidney (Australia)":{"latitude":-33.8698439,"longitude":151.2082848},"Singapore":{"latitude":1.357107,"longitude":103.8194992},"Singapore (Singapore)":{"latitude":1.357107,"longitude":103.8194992},"Sofia (Bulgaria)":{"latitude":42.6977028,"longitude":23.3217359},"Soltau (Germany)":{"latitude":52.9859666,"longitude":9.8433909},"Sophia Antipolis (France)":{"latitude":43.6195225,"longitude":7.0518158},"Sophia Antipolis, Nice (France)":{"latitude":43.695887,"longitude":7.2455175},"Sophia-Antipolis (France)":{"latitude":43.6195225,"longitude":7.0518158},"Spain":{"latitude":39.3260685,"longitude":-4.8379791},"Sri Lanka":{"latitude":7.5554942,"longitude":80.7137847},"St. Louis, Missouri (USA)":{"latitude":38.6280278,"longitude":-90.1910154},"Stockholm (Sweden)":{"latitude":59.3251172,"longitude":18.0710935},"Strasbourg (France)":{"latitude":48.584614,"longitude":7.7507127},"Surakarta (Indonesia)":{"latitude":-7.5692489,"longitude":110.828448},"Switzerland":{"latitude":46.7985624,"longitude":8.2319736},"Sydney (Australia)":{"latitude":-33.8698439,"longitude":151.2082848},"São Paulo (Brazil)":{"latitude":-1.2043218,"longitude":-47.1583944},"Taipei City (Taiwan)":{"latitude":25.061706,"longitude":121.4589414},"Taiwan":{"latitude":23.5983227,"longitude":120.83537694479215},"Tampa Bay (USA)":{"latitude":27.6886419,"longitude":-82.5723193},"Tbilisi (Georgia)":{"latitude":41.6934591,"longitude":44.8014495},"Tel Aviv (Israel)":{"latitude":32.0852997,"longitude":34.7818064},"Tel-Aviv (Israel)":{"latitude":32.0852997,"longitude":34.7818064},"Tenerife (Spain)":{"latitude":28.2935785,"longitude":-16.621447121144122},"The Brewery, City of London (UK)":{"latitude":51.5207687,"longitude":-0.0912983},"The Hague Marriott Hotel (Netherlands)":{"latitude":52.0898995,"longitude":4.282433973327428},"Thessaloniki (Greece)":{"latitude":40.6403167,"longitude":22.9352716},"Ticino (Switzerland)":{"latitude":46.3351913,"longitude":8.7525902},"Tokyo (Japan)":{"latitude":35.6840574,"longitude":139.7744912},"Torino (Italy)":{"latitude":45.0677551,"longitude":7.6824892},"Toronto (Canada)":{"latitude":43.6534817,"longitude":-79.3839347},"Toronto, Ontario (Canada)":{"latitude":43.6534817,"longitude":-79.3839347},"Toulouse (France)":{"latitude":43.6044622,"longitude":1.4442469},"Tournai (Belgium)":{"latitude":50.6056458,"longitude":3.3878179},"Tours (France)":{"latitude":47.3900474,"longitude":0.6889268},"Turin (Italy)":{"latitude":45.0677551,"longitude":7.6824892},"UK":{"latitude":6.3110548,"longitude":20.5447525},"USA":{"latitude":50.362174,"longitude":8.6428355},"Ukraine":{"latitude":37.9382413,"longitude":58.38798095730337},"Utrecht (Netherlands)":{"latitude":52.080985600000005,"longitude":5.12768396945229},"Uyo (Nigeria)":{"latitude":4.9902370000000005,"longitude":7.9974399113319485},"Valbonne (France)":{"latitude":43.641141,"longitude":7.0086255},"Valencia (Spain)":{"latitude":39.4697065,"longitude":-0.3763353},"Valladolid (Spain)":{"latitude":41.6521328,"longitude":-4.728562},"Vancouver (Canada)":{"latitude":49.2608724,"longitude":-123.113952},"Verona (Italy)":{"latitude":45.4384958,"longitude":10.9924122},"Vienna (Austria)":{"latitude":48.2083537,"longitude":16.3725042},"Vigo (Spain)":{"latitude":42.1964491,"longitude":-8.7117809},"Villeurbanne (France)":{"latitude":45.7733573,"longitude":4.8868454},"Villeurbanne, Lyon (France)":{"latitude":45.7733573,"longitude":4.8868454},"Vilnius (Lithuania)":{"latitude":54.6870458,"longitude":25.2829111},"Warsaw (Poland)":{"latitude":52.2337172,"longitude":21.071432235636493},"Washington (USA)":{"latitude":38.8950368,"longitude":-77.0365427},"Wellington (New Zealand)":{"latitude":-41.2887953,"longitude":174.7772114},"Winterthur, Zürich (Switzerland)":{"latitude":47.4991723,"longitude":8.7291498},"Wisconsin (USA)":{"latitude":44.4308975,"longitude":-89.6884637},"Wisconsin Dells, WI (USA)":{"latitude":43.6256168,"longitude":-89.7715646},"Wrocław (Poland)":{"latitude":51.1263106,"longitude":16.97819633051261},"Yamoussoukro (Ivory Coast)":{"latitude":6.8200066,"longitude":-5.2776034},"Yokohama (Japan)":{"latitude":35.4443947,"longitude":139.6367727},"Zadar (Croatia)":{"latitude":44.1168594,"longitude":15.2353257},"Zanzibar (Tanzania)":{"latitude":-6.09994425,"longitude":39.32094431715264},"Zawiercie (Poland)":{"latitude":50.4844179,"longitude":19.4333887},"Zurich (Switzerland)":{"latitude":47.3744489,"longitude":8.5410422},"Zürich (Switzerland)":{"latitude":47.3744489,"longitude":8.5410422},"ibenik (Croatia)":{"latitude":43.7350196,"longitude":15.8952045},"in Cluj-Napoca (Romania)":{"latitude":46.7688067,"longitude":23.5947163},"xx (France)":{"latitude":47.7442265,"longitude":7.4319469}}
+{
+  "Aarhus (Denmark)": {
+    "latitude": 56.1496278,
+    "longitude": 10.2134046
+  },
+  "Abuja (Nigeria)": {
+    "latitude": 9.0643305,
+    "longitude": 7.4892974
+  },
+  "Accra (Ghana)": {
+    "latitude": 5.5571096,
+    "longitude": -0.2012376
+  },
+  "Ado (Nigeria)": {
+    "latitude": 6.6,
+    "longitude": 2.933333
+  },
+  "Agadir (Morocco)": {
+    "latitude": 30.4205162,
+    "longitude": -9.5838532
+  },
+  "Ahmedabad (India)": {
+    "latitude": 23.0216238,
+    "longitude": 72.5797068
+  },
+  "Aix-en-Provence (France)": {
+    "latitude": 43.5298424,
+    "longitude": 5.4474738
+  },
+  "Alberta (Canada)": {
+    "latitude": 55.001251,
+    "longitude": -115.002136
+  },
+  "Amboise (France)": {
+    "latitude": 47.4110351,
+    "longitude": 0.983698
+  },
+  "Amsterdam (Netherlands)": {
+    "latitude": 52.3730796,
+    "longitude": 4.8924534
+  },
+  "Anglet (France)": {
+    "latitude": 43.4813927,
+    "longitude": -1.5149935
+  },
+  "Antalya (Turkey)": {
+    "latitude": 36.8872942,
+    "longitude": 30.7074549
+  },
+  "Antwerp (Belgium)": {
+    "latitude": 51.2211097,
+    "longitude": 4.3997081
+  },
+  "Athens (Greece)": {
+    "latitude": 37.9755648,
+    "longitude": 23.7348324
+  },
+  "Atlanta (USA)": {
+    "latitude": 33.7489924,
+    "longitude": -84.3902644
+  },
+  "Atlanta, GA (USA)": {
+    "latitude": 33.7489924,
+    "longitude": -84.3902644
+  },
+  "Aurora, Colorado (USA)": {
+    "latitude": 39.7405111,
+    "longitude": -104.830994
+  },
+  "Austin (USA)": {
+    "latitude": 30.2711286,
+    "longitude": -97.7436995
+  },
+  "Austin, TX (USA)": {
+    "latitude": 30.2711286,
+    "longitude": -97.7436995
+  },
+  "Australia": {
+    "latitude": -24.7761086,
+    "longitude": 134.755
+  },
+  "Austria": {
+    "latitude": 36.9148511,
+    "longitude": -4.7534501
+  },
+  "Avignon (France)": {
+    "latitude": 43.9492493,
+    "longitude": 4.8059012
+  },
+  "Baden (France)": {
+    "latitude": 47.6199988,
+    "longitude": -2.9184744
+  },
+  "Bali (Indonesia)": {
+    "latitude": -8.456018100000001,
+    "longitude": 115.27038551191185
+  },
+  "Baltimore (USA)": {
+    "latitude": 39.2908816,
+    "longitude": -76.610759
+  },
+  "Bangkok (Thailand)": {
+    "latitude": 13.8245796,
+    "longitude": 100.6224463
+  },
+  "Banjul (Gambia)": {
+    "latitude": 13.4410165,
+    "longitude": -16.56275092072591
+  },
+  "Barcelona (Spain)": {
+    "latitude": 41.3828939,
+    "longitude": 2.1774322
+  },
+  "Basel (Switzerland)": {
+    "latitude": 47.5581077,
+    "longitude": 7.5878261
+  },
+  "Beirut (Lebanon)": {
+    "latitude": 33.8959203,
+    "longitude": 35.47843
+  },
+  "Belarus": {
+    "latitude": 47.69245275,
+    "longitude": 19.797755868882057
+  },
+  "Belem (Brazil)": {
+    "latitude": -1.45056,
+    "longitude": -48.4682453
+  },
+  "Belfast (UK)": {
+    "latitude": 54.596391,
+    "longitude": -5.9301829
+  },
+  "Belgium": {
+    "latitude": 50.6402809,
+    "longitude": 4.6667145
+  },
+  "Belgrade (Serbia)": {
+    "latitude": 44.8178131,
+    "longitude": 20.4568974
+  },
+  "Bellevue, WA (USA)": {
+    "latitude": 47.6144219,
+    "longitude": -122.192337
+  },
+  "Bengaluru (India)": {
+    "latitude": 12.9767936,
+    "longitude": 77.590082
+  },
+  "Bengaluru, Karnataka (India)": {
+    "latitude": 12.9767936,
+    "longitude": 77.590082
+  },
+  "Berlin (Germany)": {
+    "latitude": 52.5170365,
+    "longitude": 13.3888599
+  },
+  "Bern (Switzerland)": {
+    "latitude": 46.9484742,
+    "longitude": 7.4521749
+  },
+  "Beurs van Berlage (Netherlands)": {
+    "latitude": 52.3750218,
+    "longitude": 4.89626468097017
+  },
+  "Bilbao (Spain)": {
+    "latitude": 43.2630018,
+    "longitude": -2.9350039
+  },
+  "Birmingham (UK)": {
+    "latitude": 52.4796992,
+    "longitude": -1.9026911
+  },
+  "Birmingham (USA)": {
+    "latitude": 33.5206824,
+    "longitude": -86.8024326
+  },
+  "Bochum (Germany)": {
+    "latitude": 51.4818111,
+    "longitude": 7.2196635
+  },
+  "Boise (USA)": {
+    "latitude": 43.6166163,
+    "longitude": -116.200886
+  },
+  "Bologna (Italy)": {
+    "latitude": 44.4938203,
+    "longitude": 11.3426327
+  },
+  "Bordeaux (France)": {
+    "latitude": 44.841225,
+    "longitude": -0.5800364
+  },
+  "Boston, Massachusetts (USA)": {
+    "latitude": 42.3554334,
+    "longitude": -71.060511
+  },
+  "Boulder CA (USA)": {
+    "latitude": 33.615491899999995,
+    "longitude": -117.39528100998477
+  },
+  "Brabrand (Denmark)": {
+    "latitude": 56.1565872,
+    "longitude": 10.1056465
+  },
+  "Brescia (Italy)": {
+    "latitude": 45.77958045,
+    "longitude": 10.4258729694612
+  },
+  "Brest (France)": {
+    "latitude": 48.3905283,
+    "longitude": -4.4860088
+  },
+  "Bristol (UK)": {
+    "latitude": 51.4538022,
+    "longitude": -2.5972985
+  },
+  "Brno (Czech Republic)": {
+    "latitude": 49.1922443,
+    "longitude": 16.6113382
+  },
+  "Broomfield, CO (USA)": {
+    "latitude": 39.9403995,
+    "longitude": -105.05208
+  },
+  "Brussels (Belgium)": {
+    "latitude": 50.8550018,
+    "longitude": 4.3512333761166175
+  },
+  "Brühl (Germany)": {
+    "latitude": 50.8291313,
+    "longitude": 6.9037057
+  },
+  "Bucharest (Romania)": {
+    "latitude": 44.4361414,
+    "longitude": 26.1027202
+  },
+  "Budapest (Hungary)": {
+    "latitude": 47.4978918,
+    "longitude": 19.0401609
+  },
+  "Bujumbura (Burundi)": {
+    "latitude": -3.3638125,
+    "longitude": 29.3675028
+  },
+  "Bulgaria": {
+    "latitude": 46.7889169,
+    "longitude": 23.6184909
+  },
+  "Bydgoszcz (Poland)": {
+    "latitude": 53.12974625,
+    "longitude": 18.029369658534854
+  },
+  "Caceres (Spain)": {
+    "latitude": 39.759172500000005,
+    "longitude": -6.1379457147709005
+  },
+  "Cairo (Egypt)": {
+    "latitude": 30.0443879,
+    "longitude": 31.2357257
+  },
+  "California (USA)": {
+    "latitude": 36.7014631,
+    "longitude": -118.755997
+  },
+  "Canada": {
+    "latitude": 61.0666922,
+    "longitude": -107.991707
+  },
+  "Cannes (France)": {
+    "latitude": 43.5515198,
+    "longitude": 7.0134418
+  },
+  "Cape Town (South Africa)": {
+    "latitude": -33.928992,
+    "longitude": 18.417396
+  },
+  "Cardiff (Wales)": {
+    "latitude": 51.4816546,
+    "longitude": -3.1791934
+  },
+  "Chambéry (France)": {
+    "latitude": 45.5662672,
+    "longitude": 5.9203636
+  },
+  "Charlotte, North Carolina (USA)": {
+    "latitude": 35.2272086,
+    "longitude": -80.8430827
+  },
+  "Charlottesville, VA (USA)": {
+    "latitude": 38.029306,
+    "longitude": -78.4766781
+  },
+  "Chattanooga (USA)": {
+    "latitude": 35.0457219,
+    "longitude": -85.3094883
+  },
+  "Chemnitz (Germany)": {
+    "latitude": 50.8323531,
+    "longitude": 12.918914
+  },
+  "Chennai (India)": {
+    "latitude": 13.0836939,
+    "longitude": 80.270186
+  },
+  "Cheverny in the Châteaux of the Loire Valley (France)": {
+    "latitude": 47.49973,
+    "longitude": 1.46013
+  },
+  "Chicago (USA)": {
+    "latitude": 41.8755616,
+    "longitude": -87.6244212
+  },
+  "Chicago, Illinois (USA)": {
+    "latitude": 41.8755616,
+    "longitude": -87.6244212
+  },
+  "Chile": {
+    "latitude": -31.7613365,
+    "longitude": -71.3187697
+  },
+  "Choisy-le-Roi (France)": {
+    "latitude": 48.7630238,
+    "longitude": 2.4093664
+  },
+  "Christchurch (New Zealand)": {
+    "latitude": -43.530955,
+    "longitude": 172.6364343
+  },
+  "Château de Massillan’ - Drome (France)": {
+    "latitude": 44.2330208,
+    "longitude": 4.793006999999999
+  },
+  "Cilacap, Jawa Tengah (Indonesia)": {
+    "latitude": -7.46167105,
+    "longitude": 108.80461463117007
+  },
+  "Clermont Ferrand (France)": {
+    "latitude": 45.7774551,
+    "longitude": 3.0819427
+  },
+  "Clermont-Ferrand (France)": {
+    "latitude": 45.7774551,
+    "longitude": 3.0819427
+  },
+  "Cleveland (USA)": {
+    "latitude": 41.4996574,
+    "longitude": -81.6936772
+  },
+  "Cluj, Transylvania (Romania)": {
+    "latitude": 46.7712101,
+    "longitude": 23.6236353
+  },
+  "Cluj-Napoca (Romania)": {
+    "latitude": 46.769379,
+    "longitude": 23.5899542
+  },
+  "Coimbra (Portugal)": {
+    "latitude": 40.2111931,
+    "longitude": -8.4294632
+  },
+  "Colombo (Sri Lanka)": {
+    "latitude": 6.9388614,
+    "longitude": 79.8542005
+  },
+  "Copenhagen (Denmark)": {
+    "latitude": 55.6867243,
+    "longitude": 12.5700724
+  },
+  "Copenhaguen (Denmark)": {
+    "latitude": 55.6867243,
+    "longitude": 12.5700724
+  },
+  "Copiapó (Chile)": {
+    "latitude": -27.3664685,
+    "longitude": -70.3322753
+  },
+  "Cracow (Poland)": {
+    "latitude": 50.0606452,
+    "longitude": 19.9370985
+  },
+  "Craiova (Romania)": {
+    "latitude": 44.3190159,
+    "longitude": 23.7965614
+  },
+  "Crete (Greece)": {
+    "latitude": 35.308495199999996,
+    "longitude": 24.46334231842296
+  },
+  "Croatia": {
+    "latitude": 45.3658443,
+    "longitude": 15.6575209
+  },
+  "Czech Republic": {
+    "latitude": 49.7439047,
+    "longitude": 15.3381061
+  },
+  "Dakar (Senegal)": {
+    "latitude": 14.693425,
+    "longitude": -17.447938
+  },
+  "Dallas/Irving, Texas (USA)": {
+    "latitude": 32.891402049999996,
+    "longitude": -96.97086265455442
+  },
+  "Darmstadt (Germany)": {
+    "latitude": 49.8851869,
+    "longitude": 8.6736295
+  },
+  "Denmark": {
+    "latitude": 55.670249,
+    "longitude": 10.3333283
+  },
+  "Denver (USA)": {
+    "latitude": 39.7392364,
+    "longitude": -104.984862
+  },
+  "Detroit (USA)": {
+    "latitude": 42.3315509,
+    "longitude": -83.0466403
+  },
+  "Dhaka (Bangladesh)": {
+    "latitude": 23.7644025,
+    "longitude": 90.389015
+  },
+  "Dijon (France)": {
+    "latitude": 47.3215806,
+    "longitude": 5.0414701
+  },
+  "Dinan (France)": {
+    "latitude": 48.4539775,
+    "longitude": -2.047687
+  },
+  "Dresden (Germany)": {
+    "latitude": 51.0493286,
+    "longitude": 13.7381437
+  },
+  "Dubai": {
+    "latitude": 2.9470179,
+    "longitude": 30.961206
+  },
+  "Dubai (United Arab Emirates)": {
+    "latitude": 25.2653471,
+    "longitude": 55.2924914
+  },
+  "Dublin (Ireland)": {
+    "latitude": 53.3493795,
+    "longitude": -6.2605593
+  },
+  "Durham, NC (USA)": {
+    "latitude": 35.996653,
+    "longitude": -78.9018053
+  },
+  "Dusseldorf (Germany)": {
+    "latitude": 51.2254018,
+    "longitude": 6.7763137
+  },
+  "Düsseldorf (Germany)": {
+    "latitude": 51.2254018,
+    "longitude": 6.7763137
+  },
+  "Ede (Netherlands)": {
+    "latitude": 52.07168255,
+    "longitude": 5.745510631034939
+  },
+  "Edinburgh (Scotland)": {
+    "latitude": 55.9533456,
+    "longitude": -3.1883749
+  },
+  "Faenza (Italy)": {
+    "latitude": 44.2855555,
+    "longitude": 11.8832055
+  },
+  "Faro (Portugal)": {
+    "latitude": 37.0162727,
+    "longitude": -7.9351771
+  },
+  "Firenze (Italy)": {
+    "latitude": 43.7698712,
+    "longitude": 11.2555757
+  },
+  "Florence (Italy)": {
+    "latitude": 43.7698712,
+    "longitude": 11.2555757
+  },
+  "Florianópolis (Brazil)": {
+    "latitude": -27.5973002,
+    "longitude": -48.5496098
+  },
+  "Florida (USA)": {
+    "latitude": 27.7567667,
+    "longitude": -81.4639835
+  },
+  "France": {
+    "latitude": 46.603354,
+    "longitude": 1.8883335
+  },
+  "Frankfurt (Germany)": {
+    "latitude": 50.1106444,
+    "longitude": 8.6820917
+  },
+  "Gardanne (France)": {
+    "latitude": 43.455613,
+    "longitude": 5.4710661
+  },
+  "Gdansk (Poland)": {
+    "latitude": 54.3706858,
+    "longitude": 18.61298210330077
+  },
+  "Geldrop (Netherlands)": {
+    "latitude": 51.4226684,
+    "longitude": 5.5607546
+  },
+  "Geneva (Switzerland)": {
+    "latitude": 46.2017559,
+    "longitude": 6.1466014
+  },
+  "Genève (Switzerland)": {
+    "latitude": 46.2017559,
+    "longitude": 6.1466014
+  },
+  "Germany": {
+    "latitude": 34.895926,
+    "longitude": -83.4665496
+  },
+  "Ghent (Belgium)": {
+    "latitude": 51.0538286,
+    "longitude": 3.7250121
+  },
+  "Glasgow (Scotland)": {
+    "latitude": 55.861155,
+    "longitude": -4.2501687
+  },
+  "Goa (India)": {
+    "latitude": 15.3004543,
+    "longitude": 74.0855134
+  },
+  "Goiana (Brazil)": {
+    "latitude": -7.560603,
+    "longitude": -34.99591
+  },
+  "Golfe du morbihan (France)": {
+    "latitude": 47.5976972,
+    "longitude": -2.7533397586005415
+  },
+  "Grand Rapids, Michigan (USA)": {
+    "latitude": 42.9632425,
+    "longitude": -85.6678639
+  },
+  "Grand-Duchy of Luxembourg (Luxembourg)": {
+    "latitude": 49.6112768,
+    "longitude": 6.129799
+  },
+  "Grenoble (France)": {
+    "latitude": 45.1875602,
+    "longitude": 5.7357819
+  },
+  "Gujarat (India)": {
+    "latitude": 22.3850051,
+    "longitude": 71.745261
+  },
+  "Hamburg (Germany)": {
+    "latitude": 53.550341,
+    "longitude": 10.000654
+  },
+  "Hannover (Germany)": {
+    "latitude": 52.3744779,
+    "longitude": 9.7385532
+  },
+  "Harare (Zimbabwe)": {
+    "latitude": -17.8567035,
+    "longitude": 31.0601584
+  },
+  "Hawai (USA)": {
+    "latitude": 19.593801499999998,
+    "longitude": -155.42837009716908
+  },
+  "Helsinki (Finland)": {
+    "latitude": 60.1674881,
+    "longitude": 24.9427473
+  },
+  "Ho chi Minh (Vietnam)": {
+    "latitude": 10.7763897,
+    "longitude": 106.7011391
+  },
+  "Hollywood (USA)": {
+    "latitude": 34.0980031,
+    "longitude": -118.329523
+  },
+  "Hong Kong": {
+    "latitude": 22.2793278,
+    "longitude": 114.1628131
+  },
+  "Honolulu, Hawai (USA)": {
+    "latitude": 21.2891309,
+    "longitude": -157.7173915
+  },
+  "Hotel New York - The Art of Marvel, Disneyland Paris (France)": {
+    "latitude": 48.8707602,
+    "longitude": 2.7877176
+  },
+  "Iasi (Romania)": {
+    "latitude": 47.1615416,
+    "longitude": 27.5837224
+  },
+  "Iceland": {
+    "latitude": 64.9841821,
+    "longitude": -18.1059013
+  },
+  "Ikorodu (Nigeria)": {
+    "latitude": 6.6191233,
+    "longitude": 3.5041271
+  },
+  "Illinois (USA)": {
+    "latitude": 40.0796606,
+    "longitude": -89.4337288
+  },
+  "India": {
+    "latitude": 22.3511148,
+    "longitude": 78.6677428
+  },
+  "Indianapolis (USA)": {
+    "latitude": 39.7683331,
+    "longitude": -86.1583502
+  },
+  "Ipswich (UK)": {
+    "latitude": 52.0579324,
+    "longitude": 1.1528095
+  },
+  "Ireland": {
+    "latitude": 52.865196,
+    "longitude": -7.9794599
+  },
+  "Islamabad (Pakistan)": {
+    "latitude": 33.6938118,
+    "longitude": 73.0651511
+  },
+  "Islas Canarias (España)": {
+    "latitude": 28.2935785,
+    "longitude": -16.621447121144122
+  },
+  "Istanbul (Turkey)": {
+    "latitude": 41.0091982,
+    "longitude": 28.9662187
+  },
+  "Jakarta (Indonesia)": {
+    "latitude": -6.175247,
+    "longitude": 106.8270488
+  },
+  "Jalingo (Nigeria)": {
+    "latitude": 8.8945377,
+    "longitude": 11.3644261
+  },
+  "Japan": {
+    "latitude": 40.9921996,
+    "longitude": -75.9078749
+  },
+  "Jinja (Uganda)": {
+    "latitude": 0.57515665,
+    "longitude": 33.28052985775423
+  },
+  "Johannesburg (South Africa)": {
+    "latitude": -26.205,
+    "longitude": 28.049722
+  },
+  "Kampala (Uganda)": {
+    "latitude": 0.3177137,
+    "longitude": 32.5813539
+  },
+  "Kathmandu (Nepal)": {
+    "latitude": 27.708317,
+    "longitude": 85.3205817
+  },
+  "Kenya": {
+    "latitude": 1.4419683,
+    "longitude": 38.4313975
+  },
+  "Kiev (Ukraine)": {
+    "latitude": 50.4500336,
+    "longitude": 30.5241361
+  },
+  "Kigali (Rwanda)": {
+    "latitude": -1.950851,
+    "longitude": 30.061507
+  },
+  "Kilkenny (Ireland)": {
+    "latitude": 52.5687098,
+    "longitude": -7.188983092181514
+  },
+  "Kitwe (Zambia)": {
+    "latitude": -12.8104186,
+    "longitude": 28.2068361
+  },
+  "Kolkata (India)": {
+    "latitude": 22.5726459,
+    "longitude": 88.3638953
+  },
+  "Kongsberg (Norway)": {
+    "latitude": 59.594550049999995,
+    "longitude": 9.670860075643745
+  },
+  "Krakow (Croatia)": {
+    "latitude": 45.5584831,
+    "longitude": 18.682409
+  },
+  "Krakow (Poland)": {
+    "latitude": 50.0619474,
+    "longitude": 19.9368564
+  },
+  "Kraków (Poland)": {
+    "latitude": 50.0619474,
+    "longitude": 19.9368564
+  },
+  "Kyiv (Ukraine)": {
+    "latitude": 50.4500336,
+    "longitude": 30.5241361
+  },
+  "L'aquila (Italy)": {
+    "latitude": 42.1368853,
+    "longitude": 13.610341022538911
+  },
+  "La Ciotat (France)": {
+    "latitude": 43.1758591,
+    "longitude": 5.6062495
+  },
+  "La Paz (Bolivia)": {
+    "latitude": -16.4955455,
+    "longitude": -68.1336229
+  },
+  "La Rochelle (France)": {
+    "latitude": 46.1591126,
+    "longitude": -1.1520434
+  },
+  "Lagos (Nigeria)": {
+    "latitude": 6.4550575,
+    "longitude": 3.3941795
+  },
+  "Lake Tahoe (USA)": {
+    "latitude": 39.08854049999999,
+    "longitude": -120.05035277301698
+  },
+  "Las Vegas (USA)": {
+    "latitude": 36.1672559,
+    "longitude": -115.148516
+  },
+  "Las Vegas, NV (USA)": {
+    "latitude": 36.1672559,
+    "longitude": -115.148516
+  },
+  "Las Vegas, Nevada (USA)": {
+    "latitude": 36.1672559,
+    "longitude": -115.148516
+  },
+  "Lausanne (Switzerland)": {
+    "latitude": 46.5218269,
+    "longitude": 6.6327025
+  },
+  "Le Mans (France)": {
+    "latitude": 48.0073849,
+    "longitude": 0.1967849
+  },
+  "Lehi, UTAH (USA)": {
+    "latitude": 40.3881114,
+    "longitude": -111.8486019
+  },
+  "Lille & Lyon (France)": {
+    "latitude": 45.6919466,
+    "longitude": 4.5946695
+  },
+  "Lille (France)": {
+    "latitude": 50.6365654,
+    "longitude": 3.0635282
+  },
+  "Lille Grand Palais (France)": {
+    "latitude": 50.6296509,
+    "longitude": 3.0749235
+  },
+  "Lille, Lyon, Nantes, Tours (France)": {
+    "latitude": 50.62925,
+    "longitude": 3.057256
+  },
+  "Lima (Peru)": {
+    "latitude": -12.0621065,
+    "longitude": -77.0365256
+  },
+  "Linz (Austria)": {
+    "latitude": 48.3059078,
+    "longitude": 14.286198
+  },
+  "Lisbon (Portugal)": {
+    "latitude": 38.7077507,
+    "longitude": -9.1365919
+  },
+  "Ljubljana (Slovenia)": {
+    "latitude": 46.0500268,
+    "longitude": 14.5069289
+  },
+  "Lokoja (Nigeria)": {
+    "latitude": 7.802355,
+    "longitude": 6.7430327
+  },
+  "London (UK)": {
+    "latitude": 51.5073359,
+    "longitude": -0.12765
+  },
+  "Los Angeles (USA)": {
+    "latitude": 34.0536909,
+    "longitude": -118.242766
+  },
+  "Los Angeles Convention Center (USA)": {
+    "latitude": 34.0414713,
+    "longitude": -118.26898072389606
+  },
+  "Louvain-La-Neuve (Belgium)": {
+    "latitude": 50.6682012,
+    "longitude": 4.6128839
+  },
+  "Luanda (Angola)": {
+    "latitude": -8.8272699,
+    "longitude": 13.2439512
+  },
+  "Ludwigsburg (Germany)": {
+    "latitude": 48.8953937,
+    "longitude": 9.1895147
+  },
+  "Lugano (Switzerland)": {
+    "latitude": 46.0050102,
+    "longitude": 8.9520281
+  },
+  "Luxembourg": {
+    "latitude": 49.6112768,
+    "longitude": 6.129799
+  },
+  "Lyon (France)": {
+    "latitude": 45.7578137,
+    "longitude": 4.8320114
+  },
+  "Lyon 3e (France)": {
+    "latitude": 45.7541777,
+    "longitude": 4.8845249
+  },
+  "MIT (USA)": {
+    "latitude": 42.3582529,
+    "longitude": -71.0966272383055
+  },
+  "Madrid (Spain)": {
+    "latitude": 40.4167047,
+    "longitude": -3.7035825
+  },
+  "Mainz (Germany)": {
+    "latitude": 50.0012314,
+    "longitude": 8.2762513
+  },
+  "Malaga (Spain)": {
+    "latitude": 36.7213028,
+    "longitude": -4.4216366
+  },
+  "Malmo (Sweden)": {
+    "latitude": 55.6052931,
+    "longitude": 13.0001566
+  },
+  "Mannheim (Germany)": {
+    "latitude": 49.4892913,
+    "longitude": 8.4673098
+  },
+  "Marne-la-Vallée (France)": {
+    "latitude": 48.8494036,
+    "longitude": 2.6727019475243083
+  },
+  "Marseille (France)": {
+    "latitude": 43.2961743,
+    "longitude": 5.3699525
+  },
+  "Mbarara (Uganda)": {
+    "latitude": -0.4180848,
+    "longitude": 30.573737377548046
+  },
+  "Melbourne (Australia)": {
+    "latitude": -37.8142454,
+    "longitude": 144.9631732
+  },
+  "Miami (USA)": {
+    "latitude": 25.7741728,
+    "longitude": -80.19362
+  },
+  "Milan (Italy)": {
+    "latitude": 45.4641943,
+    "longitude": 9.1896346
+  },
+  "Milano (Italy)": {
+    "latitude": 45.4641943,
+    "longitude": 9.1896346
+  },
+  "Minneapolis (USA)": {
+    "latitude": 44.9772995,
+    "longitude": -93.2654692
+  },
+  "Minsk (Belarus)": {
+    "latitude": 53.9024716,
+    "longitude": 27.5618225
+  },
+  "Moka (Mauritius)": {
+    "latitude": -20.2218738,
+    "longitude": 57.50275
+  },
+  "Mombasa (Kenya)": {
+    "latitude": -4.05052,
+    "longitude": 39.667169
+  },
+  "Mons (Belgium)": {
+    "latitude": 50.4549568,
+    "longitude": 3.951958
+  },
+  "Mont de Marsan (France)": {
+    "latitude": 43.8911318,
+    "longitude": -0.500972
+  },
+  "Monterey (USA)": {
+    "latitude": 36.2231079,
+    "longitude": -121.387742
+  },
+  "Monterrey (Mexico)": {
+    "latitude": 25.6802019,
+    "longitude": -100.315258
+  },
+  "Montpellier (France)": {
+    "latitude": 43.6112422,
+    "longitude": 3.8767337
+  },
+  "Montreal (Canada)": {
+    "latitude": 45.5031824,
+    "longitude": -73.5698065
+  },
+  "Montrouge (France)": {
+    "latitude": 48.8188544,
+    "longitude": 2.3194375
+  },
+  "Montréal (Canada)": {
+    "latitude": 45.5031824,
+    "longitude": -73.5698065
+  },
+  "Morocco": {
+    "latitude": 28.3347722,
+    "longitude": -10.371337908392647
+  },
+  "Moscow (Russia)": {
+    "latitude": 55.7505412,
+    "longitude": 37.6174782
+  },
+  "Mountain View (USA)": {
+    "latitude": 37.3893889,
+    "longitude": -122.0832101
+  },
+  "Mumbai (India)": {
+    "latitude": 19.08157715,
+    "longitude": 72.88662753964906
+  },
+  "Munchen (Germany)": {
+    "latitude": 48.1371079,
+    "longitude": 11.5753822
+  },
+  "Munich (Germany)": {
+    "latitude": 48.1371079,
+    "longitude": 11.5753822
+  },
+  "Murten (Switzerland)": {
+    "latitude": 46.9288643,
+    "longitude": 7.1163909
+  },
+  "München (Germany)": {
+    "latitude": 48.1371079,
+    "longitude": 11.5753822
+  },
+  "NYC (USA)": {
+    "latitude": 40.7127281,
+    "longitude": -74.0060152
+  },
+  "Nairobi (Kenya)": {
+    "latitude": -1.3026148499999999,
+    "longitude": 36.82884201813725
+  },
+  "Nancy (France)": {
+    "latitude": 48.6937223,
+    "longitude": 6.1834097
+  },
+  "Nantes (France)": {
+    "latitude": 47.2186371,
+    "longitude": -1.5541362
+  },
+  "Nashville (USA)": {
+    "latitude": 36.1622767,
+    "longitude": -86.7742984
+  },
+  "Nashville, Tennessee (USA)": {
+    "latitude": 36.1622767,
+    "longitude": -86.7742984
+  },
+  "National Harbor, Maryland (USA)": {
+    "latitude": 38.7831238,
+    "longitude": -77.0128237
+  },
+  "Netherlands": {
+    "latitude": 52.2434979,
+    "longitude": 5.6343227
+  },
+  "New Orleans, LO (USA)": {
+    "latitude": 32.1538186,
+    "longitude": -80.7602671
+  },
+  "New York (USA)": {
+    "latitude": 40.7127281,
+    "longitude": -74.0060152
+  },
+  "New York City (USA)": {
+    "latitude": 40.7127281,
+    "longitude": -74.0060152
+  },
+  "Nice (France)": {
+    "latitude": 43.7009358,
+    "longitude": 7.2683912
+  },
+  "Niort (France)": {
+    "latitude": 46.3241132,
+    "longitude": -0.4649403
+  },
+  "Nuremberg (Germany)": {
+    "latitude": 49.453872,
+    "longitude": 11.077298
+  },
+  "Nürburgring (Germany)": {
+    "latitude": 50.3309196,
+    "longitude": 6.940674171000003
+  },
+  "Omni La Costa Resort & Spa Carlsbad, California (USA)": {
+    "latitude": 33.091985449999996,
+    "longitude": -117.26610534145561
+  },
+  "Ondina (El Salvador)": {
+    "latitude": 13.794185,
+    "longitude": -88.89653
+  },
+  "Online": {
+    "latitude": 43.59047185,
+    "longitude": 3.8595132132013186
+  },
+  "Online (France)": {
+    "latitude": 43.59047185,
+    "longitude": 3.8595132132013186
+  },
+  "Orange (France)": {
+    "latitude": 44.1371311,
+    "longitude": 4.8078783
+  },
+  "Orlando, Florida (USA)": {
+    "latitude": 28.5421109,
+    "longitude": -81.3790304
+  },
+  "Orléans (France)": {
+    "latitude": 47.9027336,
+    "longitude": 1.9086066
+  },
+  "Oslo (Norway)": {
+    "latitude": 59.9133301,
+    "longitude": 10.7389701
+  },
+  "Ottawa, Ontario (Canada)": {
+    "latitude": 45.4208777,
+    "longitude": -75.6901106
+  },
+  "Owerri (Nigeria)": {
+    "latitude": 5.489736,
+    "longitude": 7.0341973
+  },
+  "Palo Alto (USA)": {
+    "latitude": 37.4443293,
+    "longitude": -122.1598465
+  },
+  "Paris (France)": {
+    "latitude": 48.8588897,
+    "longitude": 2.3200410217200766
+  },
+  "Paris(France)": {
+    "latitude": 48.8588897,
+    "longitude": 2.3200410217200766
+  },
+  "Pasadena (USA)": {
+    "latitude": 34.1476507,
+    "longitude": -118.1441551
+  },
+  "Perros-Guirec (France)": {
+    "latitude": 48.8151133,
+    "longitude": -3.4394662
+  },
+  "Phantasialand near Cologne (Germany)": {
+    "latitude": 50.8014727,
+    "longitude": 6.8765161
+  },
+  "Philadelphia (USA)": {
+    "latitude": 39.9527237,
+    "longitude": -75.1635262
+  },
+  "Phoenix (USA)": {
+    "latitude": 33.4484367,
+    "longitude": -112.074141
+  },
+  "Phuket (Thailand)": {
+    "latitude": 7.9366015,
+    "longitude": 98.3529292
+  },
+  "Plymouth (UK)": {
+    "latitude": 50.3712659,
+    "longitude": -4.1425658
+  },
+  "Pointe-Noire (Congo)": {
+    "latitude": -4.8776363,
+    "longitude": 11.9748557
+  },
+  "Poitiers (France)": {
+    "latitude": 46.5802596,
+    "longitude": 0.340196
+  },
+  "Poland": {
+    "latitude": 52.215933,
+    "longitude": 19.134422
+  },
+  "Portland (USA)": {
+    "latitude": 45.5202471,
+    "longitude": -122.674194
+  },
+  "Portland, Maine (USA)": {
+    "latitude": 43.6589742,
+    "longitude": -70.2569578
+  },
+  "Portland, OR (USA)": {
+    "latitude": 45.5202471,
+    "longitude": -122.674194
+  },
+  "Porto (Portugal)": {
+    "latitude": 41.1494512,
+    "longitude": -8.6107884
+  },
+  "Porto Alegre (Brazil)": {
+    "latitude": -30.0324999,
+    "longitude": -51.2303767
+  },
+  "Portorož (Slovenia)": {
+    "latitude": 45.5146489,
+    "longitude": 13.5910112
+  },
+  "Potsdam (Germany)": {
+    "latitude": 52.4009309,
+    "longitude": 13.0591397
+  },
+  "Poznan (Poland)": {
+    "latitude": 52.4082663,
+    "longitude": 16.9335199
+  },
+  "Prague (Czech Republic)": {
+    "latitude": 50.0874654,
+    "longitude": 14.4212535
+  },
+  "Prizren (Kosovo)": {
+    "latitude": 42.2130151,
+    "longitude": 20.7363339
+  },
+  "Quebec City (Canada)": {
+    "latitude": 46.8137431,
+    "longitude": -71.2084061
+  },
+  "Québec (Canada)": {
+    "latitude": 52.4760892,
+    "longitude": -71.8258668
+  },
+  "Raleigh (USA)": {
+    "latitude": 35.7803977,
+    "longitude": -78.6390989
+  },
+  "Raleigh, NC (USA)": {
+    "latitude": 35.7803977,
+    "longitude": -78.6390989
+  },
+  "Recife (Brazil)": {
+    "latitude": -8.0584933,
+    "longitude": -34.8848193
+  },
+  "Rennes (France)": {
+    "latitude": 48.1113387,
+    "longitude": -1.6800198
+  },
+  "Riga (Latvia)": {
+    "latitude": 56.9493977,
+    "longitude": 24.1051846
+  },
+  "Roma (Italy)": {
+    "latitude": 41.8933203,
+    "longitude": 12.4829321
+  },
+  "Romania": {
+    "latitude": 45.9852129,
+    "longitude": 24.6859225
+  },
+  "Rome (Italy)": {
+    "latitude": 41.8933203,
+    "longitude": 12.4829321
+  },
+  "Roquebrune-sur-Argens (France)": {
+    "latitude": 43.4433565,
+    "longitude": 6.6363623
+  },
+  "Rotterdam (Netherlands)": {
+    "latitude": 51.9244424,
+    "longitude": 4.47775
+  },
+  "Rouen (France)": {
+    "latitude": 49.4404591,
+    "longitude": 1.0939658
+  },
+  "Round Rock (USA)": {
+    "latitude": 30.5085915,
+    "longitude": -97.6788056
+  },
+  "Rovinj (Croatia)": {
+    "latitude": 45.0807411,
+    "longitude": 13.6417282
+  },
+  "Russia": {
+    "latitude": 40.2338211,
+    "longitude": -84.4096729
+  },
+  "Région lyonnaise (France)": {
+    "latitude": 45.764043,
+    "longitude": 4.835659
+  },
+  "SF Bay Area (USA)": {
+    "latitude": 37.7749295,
+    "longitude": -122.4194155
+  },
+  "Salt Lake City (USA)": {
+    "latitude": 40.7596198,
+    "longitude": -111.886797
+  },
+  "Salt Lake City, Utah (USA)": {
+    "latitude": 40.7596198,
+    "longitude": -111.886797
+  },
+  "San Diego (USA)": {
+    "latitude": 32.7174202,
+    "longitude": -117.1627728
+  },
+  "San Francisco (USA)": {
+    "latitude": 37.7790262,
+    "longitude": -122.419906
+  },
+  "San Francisco, CA (USA)": {
+    "latitude": 37.7790262,
+    "longitude": -122.419906
+  },
+  "San Jose (USA)": {
+    "latitude": 37.3361663,
+    "longitude": -121.890591
+  },
+  "San Miguel (El Salvador)": {
+    "latitude": 13.4803899,
+    "longitude": -88.17722
+  },
+  "Sankt Augustin (Germany)": {
+    "latitude": 50.7752776,
+    "longitude": 7.1895507
+  },
+  "Santa Clara (USA)": {
+    "latitude": 37.2333253,
+    "longitude": -121.6846349
+  },
+  "Santo Domingo (Dominican Republic)": {
+    "latitude": 18.4801972,
+    "longitude": -69.942111
+  },
+  "Seattle (USA)": {
+    "latitude": 47.6038321,
+    "longitude": -122.330062
+  },
+  "Seattle, Washington (USA)": {
+    "latitude": 47.6038321,
+    "longitude": -122.330062
+  },
+  "Seoul (South Korea)": {
+    "latitude": 37.5666791,
+    "longitude": 126.9782914
+  },
+  "Serbia": {
+    "latitude": 44.024322850000004,
+    "longitude": 21.07657433209902
+  },
+  "Shangai (China)": {
+    "latitude": 31.2312707,
+    "longitude": 121.4700152
+  },
+  "Sidney (Australia)": {
+    "latitude": -33.8698439,
+    "longitude": 151.2082848
+  },
+  "Singapore": {
+    "latitude": 1.357107,
+    "longitude": 103.8194992
+  },
+  "Singapore (Singapore)": {
+    "latitude": 1.357107,
+    "longitude": 103.8194992
+  },
+  "Sofia (Bulgaria)": {
+    "latitude": 42.6977028,
+    "longitude": 23.3217359
+  },
+  "Soltau (Germany)": {
+    "latitude": 52.9859666,
+    "longitude": 9.8433909
+  },
+  "Sophia Antipolis (France)": {
+    "latitude": 43.6195225,
+    "longitude": 7.0518158
+  },
+  "Sophia Antipolis, Nice (France)": {
+    "latitude": 43.695887,
+    "longitude": 7.2455175
+  },
+  "Sophia-Antipolis (France)": {
+    "latitude": 43.6195225,
+    "longitude": 7.0518158
+  },
+  "Spain": {
+    "latitude": 39.3260685,
+    "longitude": -4.8379791
+  },
+  "Sri Lanka": {
+    "latitude": 7.5554942,
+    "longitude": 80.7137847
+  },
+  "St. Louis, Missouri (USA)": {
+    "latitude": 38.6280278,
+    "longitude": -90.1910154
+  },
+  "Stockholm (Sweden)": {
+    "latitude": 59.3251172,
+    "longitude": 18.0710935
+  },
+  "Strasbourg (France)": {
+    "latitude": 48.584614,
+    "longitude": 7.7507127
+  },
+  "Surakarta (Indonesia)": {
+    "latitude": -7.5692489,
+    "longitude": 110.828448
+  },
+  "Switzerland": {
+    "latitude": 46.7985624,
+    "longitude": 8.2319736
+  },
+  "Sydney (Australia)": {
+    "latitude": -33.8698439,
+    "longitude": 151.2082848
+  },
+  "São Paulo (Brazil)": {
+    "latitude": -1.2043218,
+    "longitude": -47.1583944
+  },
+  "Taipei City (Taiwan)": {
+    "latitude": 25.061706,
+    "longitude": 121.4589414
+  },
+  "Taiwan": {
+    "latitude": 23.5983227,
+    "longitude": 120.83537694479215
+  },
+  "Tampa Bay (USA)": {
+    "latitude": 27.6886419,
+    "longitude": -82.5723193
+  },
+  "Tbilisi (Georgia)": {
+    "latitude": 41.6934591,
+    "longitude": 44.8014495
+  },
+  "Tel Aviv (Israel)": {
+    "latitude": 32.0852997,
+    "longitude": 34.7818064
+  },
+  "Tel-Aviv (Israel)": {
+    "latitude": 32.0852997,
+    "longitude": 34.7818064
+  },
+  "Tenerife (Spain)": {
+    "latitude": 28.2935785,
+    "longitude": -16.621447121144122
+  },
+  "The Brewery, City of London (UK)": {
+    "latitude": 51.5207687,
+    "longitude": -0.0912983
+  },
+  "The Hague Marriott Hotel (Netherlands)": {
+    "latitude": 52.0898995,
+    "longitude": 4.282433973327428
+  },
+  "Thessaloniki (Greece)": {
+    "latitude": 40.6403167,
+    "longitude": 22.9352716
+  },
+  "Ticino (Switzerland)": {
+    "latitude": 46.3351913,
+    "longitude": 8.7525902
+  },
+  "Tokyo (Japan)": {
+    "latitude": 35.6840574,
+    "longitude": 139.7744912
+  },
+  "Torino (Italy)": {
+    "latitude": 45.0677551,
+    "longitude": 7.6824892
+  },
+  "Toronto (Canada)": {
+    "latitude": 43.6534817,
+    "longitude": -79.3839347
+  },
+  "Toronto, Ontario (Canada)": {
+    "latitude": 43.6534817,
+    "longitude": -79.3839347
+  },
+  "Toulouse (France)": {
+    "latitude": 43.6044622,
+    "longitude": 1.4442469
+  },
+  "Tournai (Belgium)": {
+    "latitude": 50.6056458,
+    "longitude": 3.3878179
+  },
+  "Tours (France)": {
+    "latitude": 47.3900474,
+    "longitude": 0.6889268
+  },
+  "Turin (Italy)": {
+    "latitude": 45.0677551,
+    "longitude": 7.6824892
+  },
+  "UK": {
+    "latitude": 6.3110548,
+    "longitude": 20.5447525
+  },
+  "USA": {
+    "latitude": 50.362174,
+    "longitude": 8.6428355
+  },
+  "Ukraine": {
+    "latitude": 37.9382413,
+    "longitude": 58.38798095730337
+  },
+  "Utrecht (Netherlands)": {
+    "latitude": 52.080985600000005,
+    "longitude": 5.12768396945229
+  },
+  "Uyo (Nigeria)": {
+    "latitude": 4.9902370000000005,
+    "longitude": 7.9974399113319485
+  },
+  "Valbonne (France)": {
+    "latitude": 43.641141,
+    "longitude": 7.0086255
+  },
+  "Valencia (Spain)": {
+    "latitude": 39.4697065,
+    "longitude": -0.3763353
+  },
+  "Valladolid (Spain)": {
+    "latitude": 41.6521328,
+    "longitude": -4.728562
+  },
+  "Vancouver (Canada)": {
+    "latitude": 49.2608724,
+    "longitude": -123.113952
+  },
+  "Verona (Italy)": {
+    "latitude": 45.4384958,
+    "longitude": 10.9924122
+  },
+  "Vienna (Austria)": {
+    "latitude": 48.2083537,
+    "longitude": 16.3725042
+  },
+  "Vigo (Spain)": {
+    "latitude": 42.1964491,
+    "longitude": -8.7117809
+  },
+  "Villeurbanne (France)": {
+    "latitude": 45.7733573,
+    "longitude": 4.8868454
+  },
+  "Villeurbanne, Lyon (France)": {
+    "latitude": 45.7733573,
+    "longitude": 4.8868454
+  },
+  "Vilnius (Lithuania)": {
+    "latitude": 54.6870458,
+    "longitude": 25.2829111
+  },
+  "Warsaw (Poland)": {
+    "latitude": 52.2337172,
+    "longitude": 21.071432235636493
+  },
+  "Washington (USA)": {
+    "latitude": 38.8950368,
+    "longitude": -77.0365427
+  },
+  "Wellington (New Zealand)": {
+    "latitude": -41.2887953,
+    "longitude": 174.7772114
+  },
+  "Winterthur, Zürich (Switzerland)": {
+    "latitude": 47.4991723,
+    "longitude": 8.7291498
+  },
+  "Wisconsin (USA)": {
+    "latitude": 44.4308975,
+    "longitude": -89.6884637
+  },
+  "Wisconsin Dells, WI (USA)": {
+    "latitude": 43.6256168,
+    "longitude": -89.7715646
+  },
+  "Wrocław (Poland)": {
+    "latitude": 51.1263106,
+    "longitude": 16.97819633051261
+  },
+  "Yamoussoukro (Ivory Coast)": {
+    "latitude": 6.8200066,
+    "longitude": -5.2776034
+  },
+  "Yokohama (Japan)": {
+    "latitude": 35.4443947,
+    "longitude": 139.6367727
+  },
+  "Zadar (Croatia)": {
+    "latitude": 44.1168594,
+    "longitude": 15.2353257
+  },
+  "Zanzibar (Tanzania)": {
+    "latitude": -6.09994425,
+    "longitude": 39.32094431715264
+  },
+  "Zawiercie (Poland)": {
+    "latitude": 50.4844179,
+    "longitude": 19.4333887
+  },
+  "Zurich (Switzerland)": {
+    "latitude": 47.3744489,
+    "longitude": 8.5410422
+  },
+  "Zürich (Switzerland)": {
+    "latitude": 47.3744489,
+    "longitude": 8.5410422
+  },
+  "ibenik (Croatia)": {
+    "latitude": 43.7350196,
+    "longitude": 15.8952045
+  },
+  "in Cluj-Napoca (Romania)": {
+    "latitude": 46.7688067,
+    "longitude": 23.5947163
+  },
+  "xx (France)": {
+    "latitude": 47.7442265,
+    "longitude": 7.4319469
+  }
+}

--- a/tools/geoCodes.js
+++ b/tools/geoCodes.js
@@ -35,5 +35,13 @@ geocoder.batchGeocode(locations).then((result) => {
         }
     });
 
-    fs.writeFileSync(GEOLOCATION_OUTPUT, JSON.stringify(geoLocationsObject));
+    const orderedGeoLocationsObject = Object.keys(geoLocationsObject).sort().reduce(
+      (obj, key) => {
+        obj[key] = geoLocationsObject[key];
+        return obj;
+      },
+      {}
+    );
+
+    fs.writeFileSync(GEOLOCATION_OUTPUT, JSON.stringify(orderedGeoLocationsObject, null, '  '));
 })


### PR DESCRIPTION
This is more a proposal, so feel free to discard it if you don't see the value.

The whole point of this is to make it easy to track what is going on whenever we generate the geolocations again. What entries are added, to be able to check that directly in the diff.

The current format is a bit hard to read, and it's not easy to see what is going on.