### PR TITLE
Add opened CFP button

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ All the data (past and coming) are available publicly in JSON:
 * 14-15: [pgDayParis](https://2024.pgday.paris/) - Paris (France)
 * 14-15: [WASM IO](https://2024.wasmio.tech/) - Barcelona (Spain) <a href="https://www.papercall.io/wasmio24"><img alt="CFP WASM IO" src="https://img.shields.io/static/v1?label=CFP&message=until%201-January-2024&color=green"></a>
 * 14-15: [T3chfest](https://t3chfest.es) - Madrid (Spain) <a href="https://t3chfest.es/2024/call-for-talks"><img alt="T3chfest" src="https://img.shields.io/static/v1?label=CFP&message=until%204-December-2023&color=green"></a>
-* 14-17: [SCaLE 21x](https://www.socallinuxexpo.org) - Pasadena, CA (USA) <a href="https://www.socallinuxexpo.org/scale/21x/call-presenters"><img alt="CFP SCaLE 21x" src="https://img.shields.io/static/v1?label=CFP&message=until%201-November-2023&color=green"></a>
+* 14-17: [SCaLE 21x](https://www.socallinuxexpo.org) - Pasadena (USA) <a href="https://www.socallinuxexpo.org/scale/21x/call-presenters"><img alt="CFP SCaLE 21x" src="https://img.shields.io/static/v1?label=CFP&message=until%201-November-2023&color=green"></a>
 * 15: [DevOpsDays Los Angeles](https://devopsdays.org/events/2024-los-angeles/welcome/) - Los Angeles (USA)
 * 16: [Voxxed Days Zurich](https://voxxeddays.com/zurich/) - Zurich (Switzerland) <a href="https://vdz24.cfp.dev/"><img alt="CFP Voxxed Days Zurich" src="https://img.shields.io/static/v1?label=CFP&message=until%2019-November-2023&color=green"></a>
 * 16: [DDD Melbourne](https://www.dddmelbourne.com/) - Melbourne (Australia)

--- a/page/src/App.jsx
+++ b/page/src/App.jsx
@@ -53,13 +53,13 @@ const App = () => {
             }}
           />
           {viewType === 'calendar' && hasEvents(selectedYear) && (
-            <a href={'/developer-conference-' + selectedYear + '.ics'} className="downloadButton">
+            <a href={'/developer-conference-' + selectedYear + '.ics'} title={'Download ' + selectedYear + ' Calendar'} className="downloadButton">
               <CalendarDays />
               {selectedYear} Calendar
             </a>
           )}
           {viewType === 'calendar' && hasEvents(selectedYear) && (
-            <a href={'/developer-conference-opened-cfps.ics'} className="downloadButton">
+            <a href={'/developer-conference-opened-cfps.ics'} title="Download Opened CFP Calendar" className="downloadButton">
               <CalendarClock />
               Opened CFP Calendar
             </a>

--- a/page/src/App.jsx
+++ b/page/src/App.jsx
@@ -53,16 +53,16 @@ const App = () => {
             }}
           />
           {viewType === 'calendar' && hasEvents(selectedYear) && (
-            <a href={'/developer-conference-' + selectedYear + '.ics'} title={'Download ' + selectedYear + ' Calendar'} className="downloadButton">
-              <CalendarDays />
-              {selectedYear} Calendar
-            </a>
-          )}
-          {viewType === 'calendar' && hasEvents(selectedYear) && (
-            <a href={'/developer-conference-opened-cfps.ics'} title="Download Opened CFP Calendar" className="downloadButton">
-              <CalendarClock />
-              Opened CFP Calendar
-            </a>
+            <div className='downloadButtons'>
+              <a href={'/developer-conference-' + selectedYear + '.ics'} title={'Download ' + selectedYear + ' Calendar'} className="downloadButton">
+                <CalendarDays />
+                {selectedYear} Calendar
+              </a>
+              <a href={'/developer-conference-opened-cfps.ics'} title="Download Opened CFP Calendar" className="downloadButton">
+                <CalendarClock />
+                Opened CFP Calendar
+              </a>
+            </div>
           )}
 
           <div className="view-type-selector">

--- a/page/src/App.jsx
+++ b/page/src/App.jsx
@@ -1,6 +1,6 @@
 import {useReducer, useState} from 'react';
 
-import {ArrowDownCircle, Calendar, List, Map} from 'lucide-react';
+import {Calendar, CalendarDays, CalendarClock, List, Map} from 'lucide-react';
 
 import CalendarGrid from 'components/CalendarGrid/CalendarGrid';
 import ListView from 'components/ListView/ListView';
@@ -54,8 +54,14 @@ const App = () => {
           />
           {viewType === 'calendar' && hasEvents(selectedYear) && (
             <a href={'/developer-conference-' + selectedYear + '.ics'} className="downloadButton">
-              <ArrowDownCircle />
-              Download {selectedYear} Calendar
+              <CalendarDays />
+              {selectedYear} Calendar
+            </a>
+          )}
+          {viewType === 'calendar' && hasEvents(selectedYear) && (
+            <a href={'/developer-conference-opened-cfps.ics'} className="downloadButton">
+              <CalendarClock />
+              Opened CFP Calendar
             </a>
           )}
 

--- a/page/src/misc/geolocations.json
+++ b/page/src/misc/geolocations.json
@@ -527,6 +527,10 @@
     "latitude": 51.0538286,
     "longitude": 3.7250121
   },
+  "Gladstone (Australia)": {
+    "latitude": -23.8431724,
+    "longitude": 151.256132
+  },
   "Glasgow (Scotland)": {
     "latitude": 55.861155,
     "longitude": -4.2501687
@@ -554,6 +558,10 @@
   "Grenoble (France)": {
     "latitude": 45.1875602,
     "longitude": 5.7357819
+  },
+  "Guadalajara (Mexico)": {
+    "latitude": 20.6720375,
+    "longitude": -103.338396
   },
   "Gujarat (India)": {
     "latitude": 22.3850051,

--- a/page/src/styles/App.css
+++ b/page/src/styles/App.css
@@ -3,6 +3,7 @@ body {
   box-sizing: border-box;
 
   font-family: Inter, Arial, sans-serif;
+  flex-grow: 1;
 }
 
 .dcaTitle {
@@ -17,11 +18,17 @@ body {
   flex-grow: 1;
 }
 
+.downloadButtons {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .downloadButton {
   text-decoration: none;
   color: black;
   width: max-content;
-  margin: 1rem auto;
+  margin: 1rem;
   padding: 10px;
   border: 1px solid #ccc;
   border-radius: 3px;


### PR DESCRIPTION
It's the next step for #677 (@dadoonet ) :-)

I displayed the "open CFP" button but currently the two buttons are displayed line after line:
<img width="349" alt="image" src="https://github.com/scraly/developers-conferences-agenda/assets/2543381/fe7f394d-2c1f-4f27-ab6d-3a1fea728326">

I want to display them aside.
@gouz or @jespino , can you help me to display the two buttons next to each other? ☺️
