### PR TITLE
Try to fix ATOM feed import on feedly

### DIFF
--- a/tools/generateRSS.js
+++ b/tools/generateRSS.js
@@ -14,7 +14,7 @@ const f = new feed.Feed({
   link: "https://developers.events/",
   feedLinks: {
     json: "https://developers.events/feed-events.json",
-    atom: "https://developers.events/feed-events.atom"
+    atom: "https://developers.events/feed-events.xml"
   },
 });
 


### PR DESCRIPTION
Change 
```
atom: "https://developers.events/feed-events.atom"
```

to
```
atom: "https://developers.events/feed-events.xml"
```

to try to fix import on feedly