### PR TITLE
Fix end date for multi days events

### DIFF
--- a/tools/generateIcs.js
+++ b/tools/generateIcs.js
@@ -26,7 +26,11 @@ for (const event of allEvents) {
     vevent.addProp('DTSTAMP', new Date());
     vevent.addProp('DTSTART', formatDate(new Date(event.date[0])));
     if(event.date[1]) {
-        vevent.addProp('DTEND', formatDate(new Date(event.date[1])));
+        // When we have a multiday event, we need to add one more day
+        // Add one more day to event.date[1]
+        let endDate = new Date(event.date[1]);
+        endDate.setDate(endDate.getDate() + 1);
+        vevent.addProp('DTEND', formatDate(endDate));
     }
     vevent.addProp('LOCATION', event.location || 'unspecified');
     vevent.addProp('SUMMARY', event.name);


### PR DESCRIPTION
When we have a multi-days event, we need to set the end date to be the day after.

Otherwise, the end date is considered at the very first hour of the day which makes the last day not part of the event.

See https://github.com/scraly/developers-conferences-agenda/pull/672#issuecomment-1775600800

In the following picture, we can see the fix (in green) vs the previous version (in blue).

<img width="856" alt="image" src="https://github.com/scraly/developers-conferences-agenda/assets/274222/92af0e1f-d8be-4e90-91db-6b36cd8e1542">

