### PR TITLE
Fixing the router on published pages

### DIFF
--- a/page/src/App.jsx
+++ b/page/src/App.jsx
@@ -1,5 +1,5 @@
 import {useEffect} from 'react';
-import {BrowserRouter as Router, Routes, Route, useParams, useNavigate, useSearchParams, createSearchParams} from "react-router-dom";
+import {HashRouter as Router, Routes, Route, useParams, useNavigate, useSearchParams, createSearchParams} from "react-router-dom";
 
 import {CalendarDays, CalendarClock} from 'lucide-react';
 


### PR DESCRIPTION
The routing was working great locally, but is broken on published pages, because if you refresh the page, the server returns a 404. This is because the server is not configured to return the index.html file for all routes.

This PR fixes that by using the HashRouter instead of the BrowserRouter.