### PR TITLE
Fix multiday conferences showing in wrong month

### DIFF
--- a/page/src/app.hooks.js
+++ b/page/src/app.hooks.js
@@ -114,12 +114,12 @@ export const useDayEvents = (monthEvents, day = null) => {
       result = result.filter((e) => {
         let retval = false
 
-        if (e.date[0]) {
+        if (e.date[0] && e.date[1] == null) {
           const startDate = new Date(e.date[0])
           retval = startDate.getDate() === filterDay.getDate()
         }
 
-        if (e.date[1]) {
+        if (e.date[1] && e.date[0] == null) {
           const endDate = new Date(e.date[1])
           retval = retval || endDate.getDate() === filterDay.getDate()
         }

--- a/page/src/components/CalendarGrid/CalendarGrid.jsx
+++ b/page/src/components/CalendarGrid/CalendarGrid.jsx
@@ -12,7 +12,7 @@ const CalendarGrid = ({year}) => {
       const days = [];
       const nbDays = new Date(year, m + 1, 0).getDate();
       for (let i = 1; i <= nbDays; i++) {
-        days.push(new Date(year, m, i));
+        days.push(new Date(Date.UTC(year, m, i)));
       }
       months.push({month: m, days});
     }


### PR DESCRIPTION
Multiday conferences that span two months are shown when the end day in the start month is selected, e.g. YYC DataCon 2025 Feb 27 - Mar 1 is shown when Feb 1 is selected.

Before:
![image](https://github.com/user-attachments/assets/a7e1454c-f200-4207-b0b1-44221495e3d3)

After:
![image](https://github.com/user-attachments/assets/cfb0aa54-76dc-49c0-acfa-021cb34e3555)
