### PR TITLE
Fix: Ensure year navigator arrows are visible on mobile

### DIFF
--- a/page/src/styles/ViewSelector.css
+++ b/page/src/styles/ViewSelector.css
@@ -22,3 +22,11 @@
 .view-type-selector .view-selector:first-child {
   border-left: 0;
 }
+
+@media (max-width: 768px) {
+  .view-type-selector {
+    position: static; /* Remove absolute positioning */
+    right: auto; /* Reset right positioning */
+    margin-top: 0.5rem; /* Add some top margin for spacing */
+  }
+}

--- a/page/src/styles/YearSelector.css
+++ b/page/src/styles/YearSelector.css
@@ -34,3 +34,19 @@
   -ms-transition: transform 0.5s;
   -o-transition: transform 0.5s;
 }
+
+@media (max-width: 768px) {
+  .yearNavigatorWrapper {
+    flex-direction: column;
+    align-items: center; /* Center items horizontally */
+  }
+
+  .yearNavigator {
+    gap: 0.5rem; /* Reduce gap for smaller screens */
+    margin-bottom: 1rem; /* Add space below yearNavigator */
+  }
+
+  .bigYearLabel {
+    font-size: 3rem; /* Reduce font size for smaller screens */
+  }
+}


### PR DESCRIPTION
The right arrow button in the year navigator was not visible on mobile devices. This was due to the `ViewSelector` component overlapping the `yearNavigator` on smaller screen sizes.

This commit addresses the issue by:
1. Modifying `YearSelector.css`:
   - For screens <= 768px wide, `yearNavigatorWrapper` now uses `flex-direction: column` to stack the `yearNavigator` and `ViewSelector` vertically.
   - `align-items: center` is used to keep them centered.
   - The `gap` within `yearNavigator` and the `font-size` of `bigYearLabel` are reduced for better compactness on small screens.
   - A `margin-bottom` is added to `yearNavigator` for spacing.
2. Modifying `ViewSelector.css`:
   - For screens <= 768px wide, `.view-type-selector` (the `ViewSelector` component) now uses `position: static` instead of `position: absolute`.
   - The `right` property is reset, and a `margin-top` is added for spacing.

These changes ensure that the `ViewSelector` is displayed below the `yearNavigator` on mobile devices, preventing overlap and making both the navigation arrows and the view selector visible and usable.