### PR TITLE
Handle location not starting with an ASCII character

### DIFF
--- a/tools/mdParser.js
+++ b/tools/mdParser.js
@@ -78,22 +78,22 @@ const extractEvents = (monthMarkdown, year, month) =>
       hyperlink: eventLine.trim().replaceAll(/^.*\]\(([^)]*)\).*$/g, "$1"),
       location: eventLine
         .trim()
-        .replaceAll(/^[^\]]*[^)]*[\W-]*([^<]*).*$/g, "$1")
+        .replaceAll(/^[^\]]*[^)]*[\P{Letter}]*([^<]*).*$/ug, "$1")
         .trim(),
       city: eventLine
         .trim()
-        .replaceAll(/^[^\]]*[^)]*[\W-]*([^<]*).*$/g, "$1")
+        .replaceAll(/^[^\]]*[^)]*[\P{Letter}]*([^<]*).*$/ug, "$1")
         .trim()
-	.replaceAll(/ \& Online/g, "")
-	.replaceAll(/^([^(]*)\(.*$/g, "$1")
-	.trim(),
+        .replaceAll(/ \& Online/g, "")
+        .replaceAll(/^([^(]*)\(.*$/g, "$1")
+        .trim(),
       country: eventLine 
         .trim()
-        .replaceAll(/^[^\]]*[^)]*[\W-]*([^<]*).*$/g, "$1")
+        .replaceAll(/^[^\]]*[^)]*[\P{Letter}]*([^<]*).*$/ug, "$1")
         .trim()
-	.replaceAll(/ \& Online/g, "")
-	.replaceAll(/^[^(]*\(([^)]*)\)$/g, "$1")
-	.trim(),
+        .replaceAll(/ \& Online/g, "")
+        .replaceAll(/^[^(]*\(([^)]*)\)$/g, "$1")
+        .trim(),
       misc: eventLine.includes("</a>")
         ? eventLine.trim().replaceAll(/^.*(<a.*a>).*$/g, "$1")
         : "",


### PR DESCRIPTION
Consider that location start with a character with [the unicode general category](https://unicode.org/reports/tr18/#General_Category_Property) "Letter".

Diff before/after on generated `all-events.json`:

```diff
--- all-events.json
+++ all-events.new.json
@@ -10862,7 +10862,7 @@
         ],
         "hyperlink": "https://2022.websummercamp.com",
         "location": "Šibenik (Croatia)",
-        "city": "ibenik",
+        "city": "Šibenik",
         "country": "Croatia",
         "misc": "",
         "cfp": {},
@@ -40467,7 +40467,7 @@
         ],
         "hyperlink": "https://devconf.pl",
         "location": "Łódź (Poland)",
-        "city": "dź",
+        "city": "Łódź",
         "country": "Poland",
         "misc": "<a href=\"https://sessionize.com/devconfpl-2024\"><img alt=\"CFP DevConf 2024\" src=\"https://img.shields.io/static/v1?label=CFP&message=until%2017-May-2024&color=red\"></a>",
         "cfp": {
@@ -59607,7 +59607,7 @@
         ],
         "hyperlink": "https://devconf.pl",
         "location": "Łódź (Poland)",
-        "city": "dź",
+        "city": "Łódź",
         "country": "Poland",
         "misc": "<a href=\"https://sessionize.com/devconfpl-2025\"><img alt=\"CFP DevConf 2025\" src=\"https://img.shields.io/static/v1?label=CFP&message=until%2017-May-2025&color=red\"></a>",
         "cfp": {
```