### PR TITLE
Adds a favorites toggle button

### DIFF
--- a/page/src/components/FavoritesToggle/FavoritesToggle.jsx
+++ b/page/src/components/FavoritesToggle/FavoritesToggle.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Heart } from 'lucide-react';
+import { useSearchParams } from 'react-router-dom';
+import 'styles/FavoritesToggle.css';
+
+const FavoritesToggle = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const favorites = searchParams.get('favorites') === 'true';
+
+  const toggleFavorites = () => {
+    const newSearchParams = new URLSearchParams(searchParams);
+    if (favorites) {
+      newSearchParams.delete('favorites');
+    } else {
+      newSearchParams.set('favorites', 'true');
+    }
+    setSearchParams(newSearchParams);
+  };
+
+  return (
+    <button
+      aria-label={favorites ? 'Hide favorites' : 'Show only favorites'}
+      className={`favorites-toggle-button ${favorites ? 'strikethrough' : ''}`}
+      onClick={toggleFavorites}
+      title={favorites ? 'Hide favorites' : 'Show only favorites'}
+    >
+      <Heart size={20} />
+    </button>
+  );
+};
+
+export default FavoritesToggle;
+

--- a/page/src/components/FavoritesToggle/FavoritesToggle.jsx
+++ b/page/src/components/FavoritesToggle/FavoritesToggle.jsx
@@ -20,7 +20,7 @@ const FavoritesToggle = () => {
   return (
     <button
       aria-label={favorites ? 'Hide favorites' : 'Show only favorites'}
-      className={`favorites-toggle-button ${favorites ? 'strikethrough' : ''}`}
+      className={`favorites-toggle-button ${favorites ? '' : 'strikethrough'}`}
       onClick={toggleFavorites}
       title={favorites ? 'Hide favorites' : 'Show only favorites'}
     >

--- a/page/src/components/Filters/Filters.jsx
+++ b/page/src/components/Filters/Filters.jsx
@@ -8,6 +8,7 @@ import { useTagsVisibility } from 'contexts/TagsContext';
 import TagMultiSelect from 'components/TagMultiSelect/TagMultiSelect';
 import SelectedTags from 'components/SelectedTags/SelectedTags';
 import TagsToggle from 'components/TagsToggle/TagsToggle';
+import FavoritesToggle from 'components/FavoritesToggle/FavoritesToggle';
 
 import 'styles/Filters.css';
 import { FilterContext } from 'contexts/FilterContext';
@@ -82,6 +83,10 @@ const Filters = ({ view }) => {
       
       <div className='tags-toggle-container'>
         <TagsToggle />
+      </div>
+
+      <div className='favorites-toggle-container'>
+        <FavoritesToggle />
       </div>
 
       <div className='filters-content'>

--- a/page/src/styles/FavoritesToggle.css
+++ b/page/src/styles/FavoritesToggle.css
@@ -1,0 +1,56 @@
+.favorites-toggle-button {
+    background: white;
+    border: 2px solid #ccc;
+    border-radius: 8px;
+    padding: 8px;
+    cursor: pointer;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    transition: all 0.2s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+}
+
+.favorites-toggle-button:hover {
+    background: #f8f8f8;
+    border-color: #999;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    transform: translateY(-1px);
+}
+
+.favorites-toggle-button:active {
+    transform: translateY(0);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+}
+
+.favorites-toggle-button svg {
+    color: #555;
+    transition: color 0.2s ease;
+}
+
+.favorites-toggle-button:hover svg {
+    color: #333;
+}
+
+.favorites-toggle-button.strikethrough {
+    position: relative;
+}
+
+.favorites-toggle-button.strikethrough::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 15%;
+    right: 15%;
+    height: 2px;
+    background: #999;
+    transform: translateY(-50%) rotate(-15deg);
+    pointer-events: none;
+}
+
+.favorites-toggle-button.strikethrough svg {
+    opacity: 0.6;
+    color: #999;
+}

--- a/page/src/styles/Filters.css
+++ b/page/src/styles/Filters.css
@@ -158,3 +158,36 @@
     margin-top: 10px;
     margin-bottom: 10px;
 }
+
+.favorites-toggle-container {
+    position: fixed;
+    left: 100%;
+    top: calc(4rem + 108px);
+}
+
+.filters .favorites-toggle-container .favorites-toggle-button {
+    background: #eee;
+    border: 1px solid #ccc;
+    border-radius: 0 3px 3px 0;
+    padding: 9px;
+    cursor: pointer;
+    width: 42px;
+    height: 42px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: none;
+    transition: all 0.2s ease;
+}
+
+.filters .favorites-toggle-container .favorites-toggle-button:hover {
+    background: #ddd;
+    border-color: #999;
+    transform: none;
+    box-shadow: none;
+}
+
+.filters .favorites-toggle-container .favorites-toggle-button svg {
+    stroke-width: 2.5px;
+    color: inherit !important;
+}


### PR DESCRIPTION
Feature: new Favorites toggle button (better than click on filter, check the favorites checkbox and close the filyer).

By default, favorites are not displayed:
<img width="1036" height="528" alt="image" src="https://github.com/user-attachments/assets/654512e5-0733-43a8-8d19-1f7b855349e6" />

But we can in one click display them!
<img width="1214" height="514" alt="image" src="https://github.com/user-attachments/assets/994276a0-9cb4-4190-b5bb-1a3a16da43e1" />


