### PR TITLE
Add link to repository code in footerAdd link to repository code in footer

### DIFF
--- a/page/index.html
+++ b/page/index.html
@@ -115,6 +115,9 @@
                 Links:
             <ul>
                 <li>
+                    <a href="https://github.com/scraly/developers-conferences-agenda" target="_blank" class="footer-link">View source code on GitHub</a>
+                </li>
+                <li>
                     <a href="https://developers.events/all-events.json" target="_blank" class="footer-link">Full events list</a>
                 </li>
                 <li>


### PR DESCRIPTION
Added a "View source code on GitHub" link to the footer's links section, making it easier for visitors to find the repository and contribute to the project.

The link is positioned as the first item in the links list and follows the same styling as other footer links.