### PR TITLE
Add Direct Link to GitHub Repository in footer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "developers-conferences-agenda",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/page/index.html
+++ b/page/index.html
@@ -115,6 +115,9 @@
                 Links:
             <ul>
                 <li>
+                    <a href="https://github.com/scraly/developers-conferences-agenda" target="_blank" class="footer-link">GitHub Repository</a>
+                </li>
+                <li>
                     <a href="https://developers.events/all-events.json" target="_blank" class="footer-link">Full events list</a>
                 </li>
                 <li>


### PR DESCRIPTION
Fixes #1689. Added a link to the GitHub repo at the bottom of the page.