### PR TITLE
Add human-readable date field to all-events.json

### DIFF
--- a/tools/mdParser.js
+++ b/tools/mdParser.js
@@ -13,6 +13,14 @@ const MONTHS_SHORTNAMES = MONTHS_NAMES.map((m) => m.slice(0, 3));
 
 const getTimeStamp = (year,month,day) => new Date(Date.UTC(year,month,day,0,0,0)).getTime()
 
+const formatDateHumanReadable = (timestamp) => {
+  const date = new Date(timestamp);
+  const year = date.getUTCFullYear();
+  const month = MONTHS_NAMES[date.getUTCMonth()];
+  const day = date.getUTCDate();
+  return `${month.charAt(0).toUpperCase() + month.slice(1)}-${day}-${year}`;
+}
+
 const parseTags = () => {
   try {
     const tagsContent = fs.readFileSync(TAGS_INPUT, 'utf8');
@@ -118,13 +126,18 @@ const extractEvents = (monthMarkdown, year, month) => {
         : "";
       const misc = miscContent.replace(sponsoringLink, "").replace(cfpLink, "").trim();
 
+      const dateArray = getTimeSpan(
+        year,
+        month,
+        eventLine.trim().replaceAll(/^\s*\*\s*([0-9\/-]*).*$/g, "$1")
+      );
+
       const event = {
         name: eventLine.trim().replaceAll(/^.*[?0-9\/\-]+.*\[(.*)\].*$/g, "$1"),
-        date: getTimeSpan(
-          year,
-          month,
-          eventLine.trim().replaceAll(/^\s*\*\s*([0-9\/-]*).*$/g, "$1")
-        ),
+        date: dateArray,
+        humanReadableDate: dateArray.length === 1
+          ? formatDateHumanReadable(dateArray[0])
+          : `${formatDateHumanReadable(dateArray[0])} - ${formatDateHumanReadable(dateArray[1])}`,
         hyperlink: eventLine.trim().replaceAll(/^.*\]\(([^)]*)\).*$/g, "$1"),
         location: eventLine
           .trim()
@@ -137,7 +150,7 @@ const extractEvents = (monthMarkdown, year, month) => {
           .replaceAll(/ \& Online/g, "")
           .replaceAll(/^([^(]*)\(.*$/g, "$1")
           .trim(),
-        country: eventLine 
+        country: eventLine
           .trim()
           .replaceAll(/^[^\]]*[^)]*[\P{Letter}]*([^<]*).*$/ug, "$1")
           .trim()


### PR DESCRIPTION
## Summary

- Added `humanReadableDate` field to each event in `all-events.json` to match the format used in `all-cfps.json`
- Provides an easy-to-read date string alongside the existing timestamp arrays
- Single-day events display as `"May-15-2017"`
- Multi-day events display as `"April-25-2017 - April-28-2017"`

## Changes

- Added `formatDateHumanReadable()` helper function in `tools/mdParser.js` to convert timestamps to human-readable format
- Updated event object generation to include the `humanReadableDate` field
- The generated JSON file will now have both timestamp arrays (for programmatic use) and human-readable dates (for display)

## Example Output

```json
{
  "name": "Craft Conf",
  "date": [1493078400000, 1493337600000],
  "humanReadableDate": "April-25-2017 - April-28-2017",
  "hyperlink": "https://craft-conf.com/",
  "location": "Budapest (Hungary)",
  ...
}
```

## Test plan

- [x] Run `node tools/mdParser.js` to regenerate `all-events.json`
- [x] Verify all events now include the `humanReadableDate` field
- [x] Verify single-day events show single date format
- [x] Verify multi-day events show date range format

🤖 Generated with [Claude Code](https://claude.com/claude-code)