### PR TITLE
Fix: [GenerateTags] An event containing "," in a name will have tags generate again and again

### DIFF
--- a/tools/generateAITagsv2.js
+++ b/tools/generateAITagsv2.js
@@ -32,8 +32,12 @@ function readExistingEvents(tagsFile) {
     for (let i = 1; i < lines.length; i++) {
       const line = lines[i].trim();
       if (!line) continue;
-      const [eventId] = line.split(',');
-      existing.add(eventId.replace(/^"|"$/g, ''));
+      // Extract event_id by finding the first occurrence of ',tech:' or ',topic:' or ',language:'
+      const tagStart = line.match(/,(tech:|topic:|language:)/);
+      if (tagStart) {
+        const eventId = line.substring(0, tagStart.index);
+        existing.add(eventId);
+      }
     }
   } catch {}
   return existing;


### PR DESCRIPTION
Fix the duplicate generation of tags for event name containing a comma

Example of duplicate tags:

```
2025-12-17-Perl Community Conference, Winter 2025,tech:perl,topic:community,language:english
```