### PR TITLE
CFPView: Display the CFP closing date differently if the CFP closed tomorown or today

### DIFF
--- a/page/package-lock.json
+++ b/page/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "country-emoji": "^1.5.6",
+        "date-fns": "^4.1.0",
         "ics-js": "^0.10.2",
         "lucide-react": "0.252.0",
         "react": "^18.2.0",
@@ -2133,6 +2134,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/page/package.json
+++ b/page/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "dependencies": {
     "country-emoji": "^1.5.6",
+    "date-fns": "^4.1.0",
     "ics-js": "^0.10.2",
     "lucide-react": "0.252.0",
     "react": "^18.2.0",

--- a/page/src/components/CfpDeadline/CfpDeadline.jsx
+++ b/page/src/components/CfpDeadline/CfpDeadline.jsx
@@ -1,12 +1,19 @@
 import React from 'react';
 import { Clock, AlertCircle } from 'lucide-react';
-import { isToday, isTomorrow } from 'date-fns';
+import { isToday, isTomorrow, addDays } from 'date-fns';
 import 'styles/CfpDeadline.css';
+
+const isInTwoDays = (date) => {
+  const twoDaysFromNow = addDays(new Date(), 2);
+  return date.getDate() === twoDaysFromNow.getDate() &&
+         date.getMonth() === twoDaysFromNow.getMonth() &&
+         date.getFullYear() === twoDaysFromNow.getFullYear();
+};
 
 const CfpDeadline = ({ until, untilDate }) => {
   const date = new Date(untilDate);
   const isUrgent = isToday(date);
-  const isClosingSoon = isTomorrow(date);
+  const isClosingSoon = isTomorrow(date) || isInTwoDays(date);
 
   return (
     <div className={`cfp-deadline ${isUrgent ? 'cfp-urgent' : ''} ${isClosingSoon ? 'cfp-closing-soon' : ''}`}>

--- a/page/src/components/CfpDeadline/CfpDeadline.jsx
+++ b/page/src/components/CfpDeadline/CfpDeadline.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Clock, AlertCircle } from 'lucide-react';
+import { isToday, isTomorrow } from 'date-fns';
+import 'styles/CfpDeadline.css';
+
+const CfpDeadline = ({ until, untilDate }) => {
+  const date = new Date(untilDate);
+  const isUrgent = isToday(date);
+  const isClosingSoon = isTomorrow(date);
+
+  return (
+    <div className={`cfp-deadline ${isUrgent ? 'cfp-urgent' : ''} ${isClosingSoon ? 'cfp-closing-soon' : ''}`}>
+      {isUrgent ? (
+        <AlertCircle color="#dc2626" size={24} />
+      ) : isClosingSoon ? (
+        <Clock color="#f59e0b" size={24} />
+      ) : (
+        <Clock color="green" size={24} />
+      )}
+      <span>
+        Until {isToday(date) && ''}
+        {isTomorrow(date) && ''}
+        {until}
+      </span>
+    </div>
+  );
+};
+
+export default CfpDeadline;

--- a/page/src/components/CfpView/CfpView.jsx
+++ b/page/src/components/CfpView/CfpView.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import 'styles/CfpView.css';
-import { Clock, CalendarClock } from 'lucide-react';
+import { CalendarClock } from 'lucide-react';
 
 import { useCfpEvents, useFilters } from 'app.hooks';
 import { getMonthName, getMonthNames } from 'utils';
@@ -9,6 +9,7 @@ import FavoriteButton from '../FavoriteButton/FavoriteButton';
 import TagBadges from 'components/TagBadges/TagBadges';
 import { useFavoritesContext } from '../../contexts/FavoritesContext';
 import ShortDate from 'components/ShortDate/ShortDate';
+import CfpDeadline from 'components/CfpDeadline/CfpDeadline';
 
 const CfpView = () => {
   let events = useCfpEvents();
@@ -64,7 +65,7 @@ const CfpView = () => {
                         <FavoriteButton event={e} />
                       </div>
 
-                      <span className="until"><Clock color="green" />Until {e.cfp.until} </span>
+                      <CfpDeadline until={e.cfp.until} untilDate={e.cfp.untilDate} />
 
                       <div className="country">
                         <span className="countryFlag">{e.country != "Online" ? flag(e.country) : '🌎'}</span>

--- a/page/src/styles/CfpDeadline.css
+++ b/page/src/styles/CfpDeadline.css
@@ -1,0 +1,38 @@
+.cfp-deadline {
+  display: flex;
+  align-items: center;
+  margin-left: 1rem;
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.cfp-deadline span {
+    margin-left: 0.5rem !important;
+}
+
+.cfp-deadline.cfp-urgent {
+  color: #dc2626;
+  font-weight: 600;
+}
+
+.cfp-deadline.cfp-closing-soon {
+  color: #f59e0b;
+  font-weight: 600;
+}
+
+.cfp-deadline.cfp-urgent span,
+.cfp-deadline.cfp-closing-soon span {
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.6;
+  }
+  100% {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
If the CFP of an event will close tomorow, dsiplay the until date in orange:

<img width="1413" height="667" alt="Capture d’écran 2025-10-23 à 14 06 02" src="https://github.com/user-attachments/assets/baa18c29-de10-42cd-abdd-c7f604e54f27" />

<img width="1413" height="561" alt="Capture d’écran 2025-10-23 à 14 06 10" src="https://github.com/user-attachments/assets/e7c35bcd-debb-4943-8c39-b97800895ac4" />

If it closes today, display it in red.