### PR TITLE
Update KubeCon NA 2026 changed dates to 2026-12-09 - 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,7 +529,10 @@ All the data (past and coming) are available publicly in JSON:
 * 7-9: [Embedded Linux Conference Europe](https://events.linuxfoundation.org/embedded-linux-conference-europe/) - Prague (Czech Republic)
 * 13-16: [SRECon EMEA](https://www.usenix.org/conference/srecon26emea) - Dublin (Ireland)
 * 20-21: [PyTorch Conference 2026](https://events.linuxfoundation.org/pytorch-conference-2026/) - San Jose, CA (USA)
-* 26-29: [KubeCon + CloudNativeCon NA 2026](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america-2026/) - Salt Lake City, UT (USA)
+
+### November
+
+* 9-12: [KubeCon + CloudNativeCon NA 2026](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america-2026/) - Salt Lake City, UT (USA)
 
 ### December
 


### PR DESCRIPTION
KubeCon NA 2026 dates were updated to 2026-12-09 - 12, see https://www.linkedin.com/posts/cloud-native-computing-foundation_teamcloudnative-kubecon-cloudnativecon-activity-7389708170094350336-7RRu 