### PR TITLE
feat: add DevFest Lyon CFP & sponsoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1431,7 +1431,7 @@ All the data (past and coming) are available publicly in JSON:
 * 3: [DevDay 2026 - Alchemy](https://www.devday.be) - Mons (Belgium) <a href="https://sessionize.com/devday-2026"><img alt="CFP DevDay 2026 - Alchemy" src="https://img.shields.io/static/v1?label=CFP&message=until%2015-August-2026&color=green"></a>
 * 3: [Conf42: Chaos Engineering 2026](https://www.conf42.com/ce2026) - Online <a href="https://www.papercall.io/conf42-chaos-engineering-2026"><img alt="CFP Conf42: Chaos Engineering 2026" src="https://img.shields.io/static/v1?label=CFP&message=until%2002-November-2026&color=green"></a>
 * 3: [Scrum Day Europe](https://scrumdayeurope.com) - Utrecht (Netherlands)
-* 4: [DevFest Lyon 2026](https://devfest.gdglyon.com/) - Lyon (France)
+* 4: [DevFest Lyon 2026](https://devfest.gdglyon.com/) - Lyon (France) <a href="https://drive.google.com/drive/folders/1P8Q6wzMP-DxdlLHXzQmRpDmXhakrDWDE?usp=sharing"><img alt="Sponsoring" src="https://img.shields.io/badge/Sponsoring-8A2BE2"></a> <a href="https://conference-hall.io/devfest-lyon-2026"><img alt="CFP conference-name" src="https://img.shields.io/static/v1?label=CFP&message=until%2014-June-2026&color=green"></a>
 * 7: [Automotive Linux Summit](https://events.linuxfoundation.org/automotive-linux-summit/) - Tokyo (Japan)
 * 7: [Embedded Linux Conference Asia](https://events.linuxfoundation.org/embedded-linux-conference-asia/) - Tokyo (Japan)
 * 7-9: [Open Source Summit Japan 2026](https://events.linuxfoundation.org/open-source-summit-japan/) - Tokyo (Japan)


### PR DESCRIPTION
There’s some new information about DevFest Lyon 2026, so I’m updating the list to highlight the sponsorship opportunities and the upcoming Call for Papers 😊