### PR TITLE
Fix extra left margin on sponsor name

### DIFF
--- a/page/src/styles/App.css
+++ b/page/src/styles/App.css
@@ -272,8 +272,9 @@ input[type=text] {
   border: 2px solid #555;
 }
 
-.sponsor-name {
+.sponsor-name.sponsor-name { /* doubled class for specificity */
   font-size: 0.85rem;
+  margin: 0;
   color: #ddd;
   font-weight: 500;
 }


### PR DESCRIPTION
There's a small bit of extra space on the left of each sponsor name, making pushing them off-center.

Before:
<img width="932" height="372" alt="2026-05-10 16 56 09 Safari app (Developer Conferences Agenda)" src="https://github.com/user-attachments/assets/5fee24d1-b720-475d-b167-b487f4954728" />

After:
<img width="932" height="374" alt="2026-05-10 16 56 14 Safari app (Developer Conferences Agenda)" src="https://github.com/user-attachments/assets/b508c671-67e4-46cb-bb3d-1999f91d1aef" />
