### PR TITLE
Fix wrong dates displayed viewing in NA for example

### DIFF
--- a/page/src/app.hooks.js
+++ b/page/src/app.hooks.js
@@ -3,6 +3,7 @@ import allEvents from 'misc/all-events.json'
 import regions from 'misc/regions.json'
 import {useCallback, useMemo} from 'react'
 import {isFavorite} from './utils/favorites'
+import {getUTCDateValue, getUTCMonth, getUTCYear, isSameUTCDate, isUTCDateInRange} from './utils.js'
 
 // Controls which tag categories appear as filter dropdowns on the page.
 // Add a key to 'allowed' to create a filter for it (e.g. 'type' when type tags exist in the data).
@@ -32,7 +33,7 @@ export const parseDimensionParams = (search, dimensions) => {
 }
 
 export const useHasYearEvents = (year) => {
-  return useMemo(() => Boolean(allEvents.find((e) => new Date(e.date[0]).getFullYear() === parseInt(year, 10))), [year])
+  return useMemo(() => Boolean(allEvents.find((e) => getUTCYear(e.date[0]) === parseInt(year, 10))), [year])
 }
 
 export const useCountries = () => {
@@ -133,7 +134,7 @@ export const useYearEvents = () => {
   const [searchParams] = useSearchParams()
   const search = Object.fromEntries(searchParams)
   const regionsMap = useCountryToRegionMap()
-  const yearEvents = useMemo(() => allEvents.filter((e) => e.date[0] && new Date(e.date[0]).getFullYear() === parseInt(year, 10)), [year])
+  const yearEvents = useMemo(() => allEvents.filter((e) => e.date[0] && getUTCYear(e.date[0]) === parseInt(year, 10)), [year])
 
   return useMemo(() => {
     let result = yearEvents
@@ -169,7 +170,7 @@ export const filterCfpEventsByYear = (events, year) => {
       if (!e.cfp || !e.cfp.untilDate) return false
       if (!isCfpOpen(e.cfp.untilDate)) return false
 
-      const cfpYear = new Date(e.cfp.untilDate).getFullYear()
+      const cfpYear = getUTCYear(e.cfp.untilDate)
 
       // Only show CFPs that close in the selected year
       return cfpYear === currentYear
@@ -385,7 +386,7 @@ export const useMonthEvents = (yearEvents, month = null) => {
     if (filterMonth !== -1) {
       result = result.filter(
         (e) =>
-          (e.date[0] && new Date(e.date[0]).getMonth() === filterMonth) || (e.date[1] && new Date(e.date[1]).getMonth() === filterMonth)
+          (e.date[0] && getUTCMonth(e.date[0]) === filterMonth) || (e.date[1] && getUTCMonth(e.date[1]) === filterMonth)
       )
     }
     return result
@@ -402,23 +403,15 @@ export const useDayEvents = (monthEvents, day = null) => {
         let retval = false
 
         if (e.date[0] && e.date[1] == null) {
-          const startDate = new Date(e.date[0])
-          retval = startDate.getDate() === filterDay.getDate() && startDate.getMonth() === filterDay.getMonth() && startDate.getFullYear() === filterDay.getFullYear()
+          retval = isSameUTCDate(e.date[0], filterDay)
         }
 
         if (e.date[1] && e.date[0] == null) {
-          const endDate = new Date(e.date[1])
-          retval = retval || (endDate.getDate() === filterDay.getDate() && endDate.getMonth() === filterDay.getMonth() && endDate.getFullYear() === filterDay.getFullYear())
+          retval = retval || isSameUTCDate(e.date[1], filterDay)
         }
 
         if (e.date[0] && e.date[1]) {
-          const startDate = new Date(e.date[0])
-          const endDate = new Date(e.date[1])
-          // Normalize dates to midnight for comparison
-          const filterDayNormalized = new Date(filterDay.getFullYear(), filterDay.getMonth(), filterDay.getDate())
-          const startDateNormalized = new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate())
-          const endDateNormalized = new Date(endDate.getFullYear(), endDate.getMonth(), endDate.getDate())
-          retval = retval || (startDateNormalized <= filterDayNormalized && filterDayNormalized <= endDateNormalized)
+          retval = retval || isUTCDateInRange(filterDay, e.date[0], e.date[1])
         }
 
         return retval

--- a/page/src/components/CalendarGrid/CalendarGrid.jsx
+++ b/page/src/components/CalendarGrid/CalendarGrid.jsx
@@ -1,6 +1,7 @@
 import {useMemo} from 'react';
 
 import Calendar from 'components/Calendar/Calendar';
+import { createUTCDate } from 'utils';
 
 import 'styles/CalendarGrid.css';
 
@@ -12,7 +13,7 @@ const CalendarGrid = ({year}) => {
       const days = [];
       const nbDays = new Date(year, m + 1, 0).getDate();
       for (let i = 1; i <= nbDays; i++) {
-        days.push(new Date(year, m, i));
+        days.push(createUTCDate(year, m, i));
       }
       months.push({month: m, days});
     }

--- a/page/src/components/Day/Day.jsx
+++ b/page/src/components/Day/Day.jsx
@@ -30,7 +30,7 @@ const Day = ({date, events}) => {
         navigate(`/${year}/calendar/-1/${date.getTime()}?${searchParams.toString()}`)
       }
     >
-      {date?.getDate() || ''}
+      {date?.getUTCDate() || ''}
     </div>
   );
 };

--- a/page/src/components/SelectedEvents/SelectedEvents.jsx
+++ b/page/src/components/SelectedEvents/SelectedEvents.jsx
@@ -4,7 +4,7 @@ import {useNavigate, useSearchParams, useParams} from 'react-router-dom';
 import 'styles/SelectedEvents.css';
 import EventDisplay from '../EventDisplay/EventDisplay';
 import EventCount from '../EventCount/EventCount'
-import {formatDate, getTranslatedMonthName} from '../../utils';
+import {createUTCDate, formatDate, getTranslatedMonthName, getUTCMonth, getUTCYear} from '../../utils';
 import {useMonthEvents, useDayEvents, useYearEvents} from 'app.hooks';
 import { ArrowLeftCircle, ArrowRightCircle } from 'lucide-react';
 import { useTranslation } from 'contexts/LanguageContext';
@@ -23,10 +23,10 @@ const SelectedEvents = () => {
   let currentMonth = Number.isNaN(parsedMonth) ? -1 : parsedMonth;
 
   if (currentMonth === -1 && currentDate) {
-    currentMonth = currentDate.getMonth();
+    currentMonth = getUTCMonth(currentDate);
   }
 
-  const resolvedMonth = currentMonth !== -1 ? currentMonth : (currentDate ? currentDate.getMonth() : 0);
+  const resolvedMonth = currentMonth !== -1 ? currentMonth : (currentDate ? getUTCMonth(currentDate) : 0);
 
   const scrollToRef = useRef();
 
@@ -61,13 +61,13 @@ const SelectedEvents = () => {
         />
       );
   } else if (isDayView && currentDate) {
-    const dateYear = currentDate.getFullYear();
-    const firstDay = new Date(dateYear, 0, 1).getTime();
-    const lastDay = new Date(dateYear, 12, 0).getTime();
+    const dateYear = getUTCYear(currentDate);
+    const firstDay = createUTCDate(dateYear, 0, 1).getTime();
+    const lastDay = createUTCDate(dateYear, 11, 31).getTime();
     const today = currentDate.getTime();
     const day = 24 * 60 * 60 * 1000;
     if (today !== firstDay) {
-      const previousDayMonth = new Date(today - day).getMonth();
+      const previousDayMonth = getUTCMonth(new Date(today - day));
       previous = (
         <ArrowLeftCircle
           onClick={() =>
@@ -77,7 +77,7 @@ const SelectedEvents = () => {
       );
     }
     if (today !== lastDay) {
-      const nextDayMonth = new Date(today + day).getMonth();
+      const nextDayMonth = getUTCMonth(new Date(today + day));
       next = (
         <ArrowRightCircle
           onClick={() =>

--- a/page/src/components/ShortDate/ShortDate.jsx
+++ b/page/src/components/ShortDate/ShortDate.jsx
@@ -1,15 +1,14 @@
 import 'styles/ShortDate.css';
-import {getMonthNameShort, getTranslatedMonthNameShort} from 'utils';
+import {getTranslatedMonthNameShort, getUTCDay, getUTCMonth} from 'utils';
 import {ArrowRight} from 'lucide-react';
 import { useTranslation } from 'contexts/LanguageContext';
 
 const ShortDate = ({dates}) => {
   const { t } = useTranslation();
-  const startDate = `${new Date(dates[0]).getDate()}-${getTranslatedMonthNameShort(new Date(dates[0]).getMonth(), t)}`;
+  const startDate = `${getUTCDay(dates[0])}-${getTranslatedMonthNameShort(getUTCMonth(dates[0]), t)}`;
   let endDate = '';
   if (dates.length > 1) {
-    endDate = new Date(dates[1]).getDate();
-    endDate = `${new Date(dates[1]).getDate()}-${getTranslatedMonthNameShort(new Date(dates[1]).getMonth(), t)}`;
+    endDate = `${getUTCDay(dates[1])}-${getTranslatedMonthNameShort(getUTCMonth(dates[1]), t)}`;
   }
   if (endDate) {
     return (

--- a/page/src/utils.js
+++ b/page/src/utils.js
@@ -1,6 +1,29 @@
 const lpad2 = (number) => ('0' + number).slice(-2)
 
-export const formatDate = (date) => date.getFullYear() + '-' + lpad2(date.getMonth() + 1) + '-' + lpad2(date.getDate())
+const asDate = (dateLike) => (dateLike instanceof Date ? dateLike : new Date(dateLike))
+
+export const createUTCDate = (year, month, day) => new Date(Date.UTC(year, month, day))
+
+export const getUTCYear = (dateLike) => asDate(dateLike).getUTCFullYear()
+
+export const getUTCMonth = (dateLike) => asDate(dateLike).getUTCMonth()
+
+export const getUTCDay = (dateLike) => asDate(dateLike).getUTCDate()
+
+export const getUTCDateValue = (dateLike) => Date.UTC(
+  getUTCYear(dateLike),
+  getUTCMonth(dateLike),
+  getUTCDay(dateLike)
+)
+
+export const isSameUTCDate = (leftDate, rightDate) => getUTCDateValue(leftDate) === getUTCDateValue(rightDate)
+
+export const isUTCDateInRange = (date, startDate, endDate) => {
+  const dateValue = getUTCDateValue(date)
+  return getUTCDateValue(startDate) <= dateValue && dateValue <= getUTCDateValue(endDate)
+}
+
+export const formatDate = (date) => getUTCYear(date) + '-' + lpad2(getUTCMonth(date) + 1) + '-' + lpad2(getUTCDay(date))
 
 export const getMonthNames = () => [
   'January',

--- a/page/src/utils.test.js
+++ b/page/src/utils.test.js
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { createUTCDate, formatDate, getUTCDateValue, isSameUTCDate, isUTCDateInRange } from './utils.js'
+
+describe('UTC date helpers', () => {
+  it('formats UTC event timestamps without shifting the day', () => {
+    const eventDate = new Date(Date.UTC(2025, 5, 11))
+
+    expect(formatDate(eventDate)).toBe('2025-06-11')
+  })
+
+  it('matches the same UTC day across date instances', () => {
+    const calendarDay = createUTCDate(2025, 5, 11)
+    const eventDay = Date.UTC(2025, 5, 11)
+
+    expect(isSameUTCDate(calendarDay, eventDay)).toBe(true)
+    expect(getUTCDateValue(calendarDay)).toBe(getUTCDateValue(eventDay))
+  })
+
+  it('keeps multiday events visible on every UTC day in the range', () => {
+    const selectedDay = createUTCDate(2025, 5, 11)
+    const startDate = Date.UTC(2025, 5, 11)
+    const endDate = Date.UTC(2025, 5, 14)
+
+    expect(isUTCDateInRange(selectedDay, startDate, endDate)).toBe(true)
+    expect(isUTCDateInRange(createUTCDate(2025, 5, 14), startDate, endDate)).toBe(true)
+    expect(isUTCDateInRange(createUTCDate(2025, 5, 10), startDate, endDate)).toBe(false)
+  })
+})


### PR DESCRIPTION
This fixes a timezone bug in calendar and list views.

Event dates are stored at midnight UTC, but the UI was reading them with local-time date methods. In timezones behind UTC, especially in North America (tested with Montreal TZ), that could shift events to the previous day and cause multi-day events to disappear from the first day.

The fix makes calendar date creation, filtering, and display use UTC consistently, so events appear on the correct day in every browser timezone.

Fix #2978 