### PR TITLE
Remember & restore the last visited view instead of always redirecting to the default List view

### DIFF
--- a/page/src/App.jsx
+++ b/page/src/App.jsx
@@ -1,4 +1,5 @@
-import {HashRouter as Router, Routes, Route} from "react-router-dom";
+import { useEffect } from 'react';
+import {HashRouter as Router, Routes, Route, useLocation} from "react-router-dom";
 import 'misc/fonts/inter/inter.css';
 import 'styles/App.css';
 import 'styles/theme.css';
@@ -19,6 +20,7 @@ import AddEventButton from './components/AddEventButton/AddEventButton';
 import LanguageSelector from './components/LanguageSelector/LanguageSelector';
 import { ThemeToggle } from './components/ThemeToggle/ThemeToggle';
 import Footer from './components/Footer/Footer';
+import { extractViewFromPath, setLastVisitedView } from 'misc/lastVisitedView';
 
 const AppContent = () => {
   const { t } = useTranslation();
@@ -37,6 +39,19 @@ const AppContent = () => {
   );
 };
 
+const LastVisitedViewTracker = () => {
+  const location = useLocation();
+
+  useEffect(() => {
+    const view = extractViewFromPath(location.pathname);
+    if (view) {
+      setLastVisitedView(view);
+    }
+  }, [location.pathname]);
+
+  return null;
+};
+
 const App = () => {
   // TODO: DRY
   const filtercontextdefaults = {
@@ -51,6 +66,7 @@ const App = () => {
           <TagsProvider>
             <FilterContext.Provider value={filtercontextdefaults}>
               <Router>
+                <LastVisitedViewTracker />
                 <AppContent />
                 <Routes>
                   <Route Component={Index} path="/" />

--- a/page/src/misc/lastVisitedView.js
+++ b/page/src/misc/lastVisitedView.js
@@ -1,0 +1,41 @@
+export const LAST_VISITED_VIEW_KEY = 'dca:lastVisitedView'
+export const DEFAULT_VIEW = 'list'
+
+const VALID_VIEWS = ['cfp', 'calendar', 'list', 'map']
+const VALID_VIEWS_SET = new Set(VALID_VIEWS)
+
+export const isValidView = (view) => VALID_VIEWS_SET.has(view)
+
+export const extractViewFromPath = (pathname = '') => {
+  if (typeof pathname !== 'string') {
+    return null
+  }
+
+  const match = pathname.match(/^\/\d{4}\/(cfp|calendar|list|map)(?:\/|$)/)
+  return match ? match[1] : null
+}
+
+export const getLastVisitedView = () => {
+  if (typeof window === 'undefined') {
+    return DEFAULT_VIEW
+  }
+
+  try {
+    const view = window.localStorage.getItem(LAST_VISITED_VIEW_KEY)
+    return isValidView(view) ? view : DEFAULT_VIEW
+  } catch {
+    return DEFAULT_VIEW
+  }
+}
+
+export const setLastVisitedView = (view) => {
+  if (!isValidView(view) || typeof window === 'undefined') {
+    return
+  }
+
+  try {
+    window.localStorage.setItem(LAST_VISITED_VIEW_KEY, view)
+  } catch {
+    // Ignore storage failures (private mode, blocked storage, etc.)
+  }
+}

--- a/page/src/misc/lastVisitedView.js
+++ b/page/src/misc/lastVisitedView.js
@@ -1,5 +1,5 @@
 export const LAST_VISITED_VIEW_KEY = 'dca:lastVisitedView'
-export const DEFAULT_VIEW = 'list'
+export const DEFAULT_VIEW = 'calendar'
 
 const VALID_VIEWS = ['cfp', 'calendar', 'list', 'map']
 const VALID_VIEWS_SET = new Set(VALID_VIEWS)

--- a/page/src/misc/lastVisitedView.test.js
+++ b/page/src/misc/lastVisitedView.test.js
@@ -30,6 +30,7 @@ describe('lastVisitedView', () => {
   describe('extractViewFromPath', () => {
     it('returns the view for supported routes', () => {
       expect(extractViewFromPath('/2026/list')).toBe('list')
+      expect(extractViewFromPath('/2026/calendar')).toBe('calendar')
       expect(extractViewFromPath('/2026/cfp')).toBe('cfp')
       expect(extractViewFromPath('/2026/map')).toBe('map')
       expect(extractViewFromPath('/2026/calendar/4/123456')).toBe('calendar')

--- a/page/src/misc/lastVisitedView.test.js
+++ b/page/src/misc/lastVisitedView.test.js
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  DEFAULT_VIEW,
+  LAST_VISITED_VIEW_KEY,
+  extractViewFromPath,
+  getLastVisitedView,
+  setLastVisitedView
+} from './lastVisitedView'
+
+describe('lastVisitedView', () => {
+  const createStorage = () => {
+    let store = {}
+
+    return {
+      clear: () => {
+        store = {}
+      },
+      getItem: (key) => store[key] ?? null,
+      setItem: (key, value) => {
+        store[key] = String(value)
+      }
+    }
+  }
+
+  beforeEach(() => {
+    global.window = { localStorage: createStorage() }
+    window.localStorage.clear()
+  })
+
+  describe('extractViewFromPath', () => {
+    it('returns the view for supported routes', () => {
+      expect(extractViewFromPath('/2026/list')).toBe('list')
+      expect(extractViewFromPath('/2026/cfp')).toBe('cfp')
+      expect(extractViewFromPath('/2026/map')).toBe('map')
+      expect(extractViewFromPath('/2026/calendar/4/123456')).toBe('calendar')
+    })
+
+    it('returns null for unsupported paths', () => {
+      expect(extractViewFromPath('/')).toBeNull()
+      expect(extractViewFromPath('/2026')).toBeNull()
+      expect(extractViewFromPath('/2026/unknown')).toBeNull()
+    })
+  })
+
+  describe('storage helpers', () => {
+    it('returns default view when there is no stored value', () => {
+      expect(getLastVisitedView()).toBe(DEFAULT_VIEW)
+    })
+
+    it('stores and retrieves a valid view', () => {
+      setLastVisitedView('map')
+      expect(getLastVisitedView()).toBe('map')
+    })
+
+    it('ignores invalid values and keeps default fallback', () => {
+      setLastVisitedView('invalid-view')
+      expect(window.localStorage.getItem(LAST_VISITED_VIEW_KEY)).toBeNull()
+      expect(getLastVisitedView()).toBe(DEFAULT_VIEW)
+    })
+  })
+})

--- a/page/src/routes/index.jsx
+++ b/page/src/routes/index.jsx
@@ -1,9 +1,10 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import { getLastVisitedView } from 'misc/lastVisitedView';
 
 export function Index() {
     const navigate = useNavigate();
     useEffect(() => {
-        return navigate('/' + new Date().getFullYear());
-    }, []);
+        return navigate(`/${new Date().getFullYear()}/${getLastVisitedView()}`, { replace: true });
+    }, [navigate]);
 };

--- a/page/src/routes/year.jsx
+++ b/page/src/routes/year.jsx
@@ -1,10 +1,11 @@
 import { useEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import { getLastVisitedView } from 'misc/lastVisitedView';
 
 export function Year() {
     const {year} = useParams();
     const navigate = useNavigate();
     useEffect(() => {
-        return navigate('/' + year + '/calendar');
-    }, [year]);
+        return navigate(`/${year}/${getLastVisitedView()}`, { replace: true });
+    }, [year, navigate]);
 }

--- a/page/src/styles/ViewSelector.css
+++ b/page/src/styles/ViewSelector.css
@@ -17,6 +17,14 @@
 
 .view-type-selector .view-selector.selected {
   background: var(--bg-muted);
+  color: var(--color-primary-dark);
+  box-shadow: inset 0 -2px 0 var(--color-primary);
+}
+
+[data-theme="light"] .view-type-selector .view-selector.selected,
+:root .view-type-selector .view-selector.selected {
+  background: #dfe7f5;
+  box-shadow: inset 0 -2px 0 var(--color-primary), inset 0 0 0 1px var(--border-dark);
 }
 
 .view-type-selector .view-selector:first-child {


### PR DESCRIPTION
* Added the persistance of the last visited view (cfp, calendar, list, map) in the local storage
* If existing, redirect to the last visited view
* Save the current view
* It was not really easy to know what was the current view, improve the visibility of the selected view for light and dark themes:
<img width="311" height="154" alt="Capture d’écran 2026-05-29 à 18 18 49" src="https://github.com/user-attachments/assets/f967f58c-3452-4981-99e7-b91f93610e8b" />

Fix #3098 