### PR TITLE
Add ELC Conference

### DIFF
--- a/METADATA.csv
+++ b/METADATA.csv
@@ -157,3 +157,4 @@ event_id,attendees
 2027-04-27-PHP Tek,attendees:200
 2026-10-14-The Autonomous Production Ops Summit 2026 | NeuBird AI,attendees:200
 2026-08-27-Cost Alongside Quality: Proving the ROI of Your Coding Agents and AI Apps,attendees:200
+2027-04-17-ELC Conference,attendees:500

--- a/README.md
+++ b/README.md
@@ -2126,6 +2126,7 @@ All the data (past and coming) are available publicly in JSON:
 * 13-15: [Analytics and Data Summit 2027](http://andouc.org) - Redwood Shores, CA (USA) <a href="https://sessionize.com/analytics-and-data-summit-2027"><img alt="CFP Analytics and Data Summit 2027" src="https://img.shields.io/static/v1?label=CFP&message=until%2007-November-2026&color=green"></a>
 * 14-15: [Devopsdays Zurich](https://devopsdays.org/events/2027-zurich) - Zurich (Germany)
 * 15-16: [GENAIX: Global Generative & Agentic AI Summit](https://genaixworld.com) - Singapore (Singapore) <a href="https://www.cfp.net"><img alt="CFP GENAIX: Global Generative & Agentic AI Summit" src="https://img.shields.io/static/v1?label=CFP&message=until%2015-October-2026&color=green"></a>
+* 17: [ELC Conference](https://elc-conference.io/) - Prague (Czech Republic)
 * 21: [AiX Conference](https://aixconf.co.uk) - Newcastle upon Tyne (UK)
 * 25-30: [STAREAST 2027](https://stareast.techwell.com/) - Orlando, FL (USA) <a href="https://stareast.techwell.com/speak-stareast"><img alt="CFP STAREAST 2027" src="https://img.shields.io/static/v1?label=CFP&message=until%2006-September-2026&color=green"></a>
 * 27-29: [PHP Tek](https://phptek.io) - Chicago, IL (USA) <a href="https://cfp.phptek.io"><img alt="CFP PHP Tek" src="https://img.shields.io/static/v1?label=CFP&message=until%2031-October-2026&color=green"></a> <a href="https://partnership-program.phparch.com/ala-cart#phptek"><img alt="Sponsoring" src="https://img.shields.io/badge/sponsoring-8A2BE2"></a>

--- a/README.md
+++ b/README.md
@@ -2126,7 +2126,7 @@ All the data (past and coming) are available publicly in JSON:
 * 13-15: [Analytics and Data Summit 2027](http://andouc.org) - Redwood Shores, CA (USA) <a href="https://sessionize.com/analytics-and-data-summit-2027"><img alt="CFP Analytics and Data Summit 2027" src="https://img.shields.io/static/v1?label=CFP&message=until%2007-November-2026&color=green"></a>
 * 14-15: [Devopsdays Zurich](https://devopsdays.org/events/2027-zurich) - Zurich (Germany)
 * 15-16: [GENAIX: Global Generative & Agentic AI Summit](https://genaixworld.com) - Singapore (Singapore) <a href="https://www.cfp.net"><img alt="CFP GENAIX: Global Generative & Agentic AI Summit" src="https://img.shields.io/static/v1?label=CFP&message=until%2015-October-2026&color=green"></a>
-* 17: [ELC Conference](https://elc-conference.io/) - Prague (Czech Republic)
+* 17: [ELC Conference](https://elc-conference.io/) - Prague (Czechia)
 * 21: [AiX Conference](https://aixconf.co.uk) - Newcastle upon Tyne (UK)
 * 25-30: [STAREAST 2027](https://stareast.techwell.com/) - Orlando, FL (USA) <a href="https://stareast.techwell.com/speak-stareast"><img alt="CFP STAREAST 2027" src="https://img.shields.io/static/v1?label=CFP&message=until%2006-September-2026&color=green"></a>
 * 27-29: [PHP Tek](https://phptek.io) - Chicago, IL (USA) <a href="https://cfp.phptek.io"><img alt="CFP PHP Tek" src="https://img.shields.io/static/v1?label=CFP&message=until%2031-October-2026&color=green"></a> <a href="https://partnership-program.phparch.com/ala-cart#phptek"><img alt="Sponsoring" src="https://img.shields.io/badge/sponsoring-8A2BE2"></a>


### PR DESCRIPTION
Adding the Engineering Leaders Community's annual conference for engineering leaders (VPEs, CTOs, staff/principal engineers), held in Prague each spring. Next edition: 17 April 2027. Meets the eligibility criteria — open to the public, external speakers (past editions featured Netflix and Stripe), targets a developer/tech leadership audience, full-day event.