### PR TITLE
CFP Companion

### DIFF
--- a/page/src/App.jsx
+++ b/page/src/App.jsx
@@ -10,6 +10,7 @@ import { DatePage } from 'routes/datepage';
 import { MapPage } from 'routes/mappage';
 import { ListPage } from 'routes/listpage';
 import { CfpPage } from 'routes/cfppage';
+import { CfpCompanionPage } from 'routes/cfpcompanionpage';
 import { FilterContext } from 'contexts/FilterContext';
 import { FavoritesProvider } from 'contexts/FavoritesContext';
 import { TagsProvider } from 'contexts/TagsContext';
@@ -75,6 +76,7 @@ const App = () => {
                   <Route Component={MapPage} path="/:year/map" />
                   <Route Component={ListPage} path="/:year/list" />
                   <Route Component={CfpPage} path="/:year/cfp" />
+                  <Route Component={CfpCompanionPage} path="/:year/cfp-companion" />
                 </Routes>
                 <ScrollToTopButton />
                 <Footer />

--- a/page/src/app.hooks.js
+++ b/page/src/app.hooks.js
@@ -204,6 +204,28 @@ export const useCfpEvents = () => {
   }, [year, searchParams, regionsMap])
 }
 
+export const filterCfpCompanionEventsByYear = (events, year) => {
+  const currentYear = parseInt(year, 10)
+
+  return events.filter(event => (
+    event.date[0]
+    && getUTCYear(event.date[0]) === currentYear
+    && event.cfp?.untilDate
+  ))
+}
+
+export const useCfpCompanionEvents = () => {
+  const { year } = useParams()
+  const [searchParams] = useSearchParams()
+  const search = Object.fromEntries(searchParams)
+  const regionsMap = useCountryToRegionMap()
+
+  return useMemo(() => {
+    const events = filterCfpCompanionEventsByYear(allEvents, year)
+    return applyCommonFilters(events, search, regionsMap)
+  }, [year, searchParams, regionsMap])
+}
+
 /**
  * Filter events by CFP until a particular date
  * Results are sorted by CFP deadline (earliest first)

--- a/page/src/app.hooks.useCfpEvents.test.js
+++ b/page/src/app.hooks.useCfpEvents.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { filterCfpEventsByYear } from './app.hooks.js'
+import { filterCfpCompanionEventsByYear, filterCfpEventsByYear } from './app.hooks.js'
 
 /**
  * The CFP view should show events with open CFPs where:
@@ -133,5 +133,26 @@ describe('useCfpEvents - CFP year filtering', () => {
     // Should only show the valid CFP event
     expect(result).toHaveLength(1)
     expect(result[0].name).toBe('Valid CFP')
+  })
+})
+
+describe('CFP Companion year filtering', () => {
+  it('keeps events with closed CFPs in the event year', () => {
+    const events = [
+      {
+        name: 'Past CFP',
+        cfp: { untilDate: '2025-12-01T00:00:00Z' },
+        date: ['2026-06-10T00:00:00Z']
+      },
+      {
+        name: 'Other Event Year',
+        cfp: { untilDate: '2026-01-20T00:00:00Z' },
+        date: ['2027-06-10T00:00:00Z']
+      }
+    ]
+
+    const result = filterCfpCompanionEventsByYear(events, '2026')
+
+    expect(result.map(event => event.name)).toEqual(['Past CFP'])
   })
 })

--- a/page/src/components/CfpCompanionView/CfpCompanionView.jsx
+++ b/page/src/components/CfpCompanionView/CfpCompanionView.jsx
@@ -5,6 +5,7 @@ import 'styles/CfpCompanionView.css'
 import { useFilters } from 'app.hooks'
 import { getMonthName, getMonthNames, getTranslatedMonthName } from 'utils'
 import ShortDate from 'components/ShortDate/ShortDate'
+import FavoriteButton from 'components/FavoriteButton/FavoriteButton'
 import TagBadges from 'components/TagBadges/TagBadges'
 import CfpSpeakerStatus from 'components/CfpSpeakerStatus/CfpSpeakerStatus'
 import { useTranslation } from 'contexts/LanguageContext'
@@ -44,6 +45,7 @@ const CfpCompanionView = ({ events }) => {
 
               return (
                 <div className="event-list-entry" key={eventId}>
+                  <FavoriteButton event={event} />
                   <CfpSpeakerStatus eventId={eventId} />
                   <div className="event-details">
                     <div className="event-date-fav">

--- a/page/src/components/CfpCompanionView/CfpCompanionView.jsx
+++ b/page/src/components/CfpCompanionView/CfpCompanionView.jsx
@@ -1,0 +1,69 @@
+import React from 'react'
+
+import 'styles/CfpCompanionView.css'
+
+import { useFilters } from 'app.hooks'
+import { getMonthName, getMonthNames, getTranslatedMonthName } from 'utils'
+import ShortDate from 'components/ShortDate/ShortDate'
+import TagBadges from 'components/TagBadges/TagBadges'
+import CfpSpeakerStatus from 'components/CfpSpeakerStatus/CfpSpeakerStatus'
+import { useTranslation } from 'contexts/LanguageContext'
+
+const CfpCompanionView = ({ events }) => {
+  const { toggleTag } = useFilters()
+  const { t } = useTranslation()
+
+  const sortedEvents = [...events].sort((firstEvent, secondEvent) => (
+    new Date(firstEvent.date[0]) - new Date(secondEvent.date[0])
+  ))
+
+  const eventsByMonth = sortedEvents.reduce((result, event) => {
+    const monthKey = getMonthName(new Date(event.date[0]).getMonth())
+    if (!result[monthKey]) {
+      result[monthKey] = []
+    }
+    result[monthKey].push(event)
+    return result
+  }, {})
+
+  const monthOrder = Object.keys(eventsByMonth).sort((firstMonth, secondMonth) => (
+    getMonthNames().indexOf(firstMonth) - getMonthNames().indexOf(secondMonth)
+  ))
+
+  return (
+    <div className="listView cfp-companion-view">
+      {monthOrder.map(month => {
+        const monthIndex = getMonthNames().indexOf(month)
+        const translatedMonth = getTranslatedMonthName(monthIndex, t)
+
+        return (
+          <React.Fragment key={month}>
+            <h1>{t('months.monthEvents').replace('{month}', translatedMonth)}</h1>
+            {eventsByMonth[month].map(event => {
+              const eventId = `${event.name}-${event.date[0]}`
+
+              return (
+                <div className="event-list-entry" key={eventId}>
+                  <div className="event-details">
+                    <div className="event-date-fav">
+                      <ShortDate dates={event.date} />
+                    </div>
+                    <div className="event-list-header">
+                      <b>{event.hyperlink ? <a className="title" href={event.hyperlink} rel="noreferrer" target="_blank">{event.name}</a> : event.name}</b>
+                      <span>{event.location}</span>
+                      {typeof event.attendees === 'number' ? <span className="attendees">👥 {event.attendees}</span> : null}
+                    </div>
+                  </div>
+                  <TagBadges onTagClick={toggleTag} tags={event.tags} />
+                  <CfpSpeakerStatus eventId={eventId} />
+                </div>
+              )
+            })}
+          </React.Fragment>
+        )
+      })}
+    </div>
+  )
+}
+
+export default CfpCompanionView

--- a/page/src/components/CfpCompanionView/CfpCompanionView.jsx
+++ b/page/src/components/CfpCompanionView/CfpCompanionView.jsx
@@ -44,6 +44,7 @@ const CfpCompanionView = ({ events }) => {
 
               return (
                 <div className="event-list-entry" key={eventId}>
+                  <CfpSpeakerStatus eventId={eventId} />
                   <div className="event-details">
                     <div className="event-date-fav">
                       <ShortDate dates={event.date} />
@@ -55,7 +56,6 @@ const CfpCompanionView = ({ events }) => {
                     </div>
                   </div>
                   <TagBadges onTagClick={toggleTag} tags={event.tags} />
-                  <CfpSpeakerStatus eventId={eventId} />
                 </div>
               )
             })}

--- a/page/src/components/CfpCompanionView/CfpCompanionView.jsx
+++ b/page/src/components/CfpCompanionView/CfpCompanionView.jsx
@@ -3,18 +3,22 @@ import React from 'react'
 import 'styles/CfpCompanionView.css'
 
 import { useFilters } from 'app.hooks'
+import { useSearchParams } from 'react-router-dom'
 import { getMonthName, getMonthNames, getTranslatedMonthName } from 'utils'
 import ShortDate from 'components/ShortDate/ShortDate'
 import FavoriteButton from 'components/FavoriteButton/FavoriteButton'
 import TagBadges from 'components/TagBadges/TagBadges'
 import CfpSpeakerStatus from 'components/CfpSpeakerStatus/CfpSpeakerStatus'
 import { useTranslation } from 'contexts/LanguageContext'
+import { filterEventsBySpeakerStatus } from 'utils/cfpSpeakerStatuses'
 
 const CfpCompanionView = ({ events }) => {
   const { toggleTag } = useFilters()
   const { t } = useTranslation()
+  const [searchParams] = useSearchParams()
+  const selectedStatuses = (searchParams.get('cfpStatus') || '').split(',').filter(Boolean)
 
-  const sortedEvents = [...events].sort((firstEvent, secondEvent) => (
+  const sortedEvents = [...filterEventsBySpeakerStatus(events, selectedStatuses)].sort((firstEvent, secondEvent) => (
     new Date(firstEvent.date[0]) - new Date(secondEvent.date[0])
   ))
 

--- a/page/src/components/CfpCompanionView/CfpCompanionView.test.js
+++ b/page/src/components/CfpCompanionView/CfpCompanionView.test.js
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { filterEventsBySpeakerStatus, setCfpSpeakerStatus } from '../../utils/cfpSpeakerStatuses'
+
+describe('CFP Companion status filtering', () => {
+  const storage = new Map()
+  const events = [
+    { name: 'Pending Conference', date: ['2026-06-01'] },
+    { name: 'Accepted Conference', date: ['2026-06-02'] },
+    { name: 'Rejected Conference', date: ['2026-06-03'] },
+    { name: 'Untracked Conference', date: ['2026-06-04'] }
+  ]
+
+  beforeEach(() => {
+    storage.clear()
+    vi.stubGlobal('localStorage', {
+      getItem: vi.fn(key => storage.get(key) || null),
+      setItem: vi.fn((key, value) => storage.set(key, value))
+    })
+    setCfpSpeakerStatus('Pending Conference-2026-06-01', 'applied')
+    setCfpSpeakerStatus('Accepted Conference-2026-06-02', 'accepted')
+    setCfpSpeakerStatus('Rejected Conference-2026-06-03', 'rejected')
+  })
+
+  it('filters events by their speaker status', () => {
+    expect(filterEventsBySpeakerStatus(events, ['pending']).map(event => event.name)).toEqual(['Pending Conference'])
+    expect(filterEventsBySpeakerStatus(events, ['accepted']).map(event => event.name)).toEqual(['Accepted Conference'])
+    expect(filterEventsBySpeakerStatus(events, ['rejected']).map(event => event.name)).toEqual(['Rejected Conference'])
+  })
+
+  it('combines selected statuses and shows all events without a filter', () => {
+    expect(filterEventsBySpeakerStatus(events, ['accepted', 'rejected']).map(event => event.name)).toEqual([
+      'Accepted Conference',
+      'Rejected Conference'
+    ])
+    expect(filterEventsBySpeakerStatus(events, [])).toEqual(events)
+  })
+})

--- a/page/src/components/CfpSpeakerStatus/CfpSpeakerStatus.jsx
+++ b/page/src/components/CfpSpeakerStatus/CfpSpeakerStatus.jsx
@@ -18,7 +18,7 @@ const CfpSpeakerStatus = ({ eventId }) => {
 
   const selectStatus = (nextStatus) => {
     setCfpSpeakerStatus(eventId, nextStatus)
-    setStatus(currentStatus => currentStatus === nextStatus ? undefined : nextStatus)
+    setStatus(getCfpSpeakerStatus(eventId))
   }
 
   return (
@@ -26,8 +26,8 @@ const CfpSpeakerStatus = ({ eventId }) => {
       {statuses.map(({ id, Icon }) => (
         <button
           aria-label={t(`cfp.${id}`)}
-          aria-pressed={status === id}
-          className={`cfp-speaker-status-button ${id} ${status === id ? 'selected' : ''}`}
+          aria-pressed={id === 'applied' ? status.applied : status.outcome === id}
+          className={`cfp-speaker-status-button ${id} ${(id === 'applied' ? status.applied : status.outcome === id) ? 'selected' : ''}`}
           key={id}
           onClick={() => selectStatus(id)}
           title={t(`cfp.${id}`)}

--- a/page/src/components/CfpSpeakerStatus/CfpSpeakerStatus.jsx
+++ b/page/src/components/CfpSpeakerStatus/CfpSpeakerStatus.jsx
@@ -1,0 +1,43 @@
+import { useState } from 'react'
+
+import { Check, FileText, X } from 'lucide-react'
+
+import { getCfpSpeakerStatus, setCfpSpeakerStatus } from 'utils/cfpSpeakerStatuses'
+import { useTranslation } from 'contexts/LanguageContext'
+import 'styles/CfpSpeakerStatus.css'
+
+const statuses = [
+  { id: 'applied', Icon: FileText },
+  { id: 'accepted', Icon: Check },
+  { id: 'rejected', Icon: X }
+]
+
+const CfpSpeakerStatus = ({ eventId }) => {
+  const { t } = useTranslation()
+  const [status, setStatus] = useState(() => getCfpSpeakerStatus(eventId))
+
+  const selectStatus = (nextStatus) => {
+    setCfpSpeakerStatus(eventId, nextStatus)
+    setStatus(currentStatus => currentStatus === nextStatus ? undefined : nextStatus)
+  }
+
+  return (
+    <div aria-label={t('cfp.companionStatus')} className="cfp-speaker-status">
+      {statuses.map(({ id, Icon }) => (
+        <button
+          aria-label={t(`cfp.${id}`)}
+          aria-pressed={status === id}
+          className={`cfp-speaker-status-button ${id} ${status === id ? 'selected' : ''}`}
+          key={id}
+          onClick={() => selectStatus(id)}
+          title={t(`cfp.${id}`)}
+          type="button"
+        >
+          <Icon aria-hidden="true" size={18} />
+        </button>
+      ))}
+    </div>
+  )
+}
+
+export default CfpSpeakerStatus

--- a/page/src/components/CfpView/CfpView.jsx
+++ b/page/src/components/CfpView/CfpView.jsx
@@ -11,9 +11,11 @@ import { useFavoritesContext } from '../../contexts/FavoritesContext';
 import { useTranslation } from 'contexts/LanguageContext';
 import ShortDate from 'components/ShortDate/ShortDate';
 import CfpDeadline from 'components/CfpDeadline/CfpDeadline';
+import CfpSpeakerStatus from 'components/CfpSpeakerStatus/CfpSpeakerStatus';
 
-const CfpView = () => {
-  let events = useCfpEvents();
+const CfpView = ({ events: providedEvents, showSpeakerStatuses = false }) => {
+  const cfpEvents = useCfpEvents();
+  let events = providedEvents || cfpEvents;
   const { isFavorite } = useFavoritesContext();
   const { toggleTag } = useFilters();
   const { t } = useTranslation();
@@ -22,15 +24,15 @@ const CfpView = () => {
     toggleTag(key, value);
   };
 
-  // Sort CFPs based on the closing date
+  const groupingDate = event => showSpeakerStatuses ? event.date[0] : event.cfp.untilDate;
+
   events = events.sort((a, b) => {
-    if (!a.cfp?.untilDate || !b.cfp?.untilDate) return 0;
-    return new Date(a.cfp.untilDate) - new Date(b.cfp.untilDate);
+    return new Date(groupingDate(a)) - new Date(groupingDate(b));
   });
 
   const eventsByMonth = events.reduce((acc, cur) => {
     let monthKey;
-    monthKey = getMonthName(new Date(cur.cfp.untilDate).getMonth());
+    monthKey = getMonthName(new Date(groupingDate(cur)).getMonth());
     if (!acc[monthKey]) {
       acc[monthKey] = [];
     }
@@ -47,14 +49,14 @@ const CfpView = () => {
   });
 
   return (
-    <div className="cfpView">
+    <div className={`cfpView ${showSpeakerStatuses ? 'cfp-companion' : ''}`}>
       {monthOrder.map(month => {
         const monthIndex = getMonthNames().indexOf(month);
         const translatedMonth = getTranslatedMonthName(monthIndex, t);
         
         return (
           <React.Fragment key={month}>
-            <h1>{t('months.monthCfpDeadlines').replace('{month}', translatedMonth)}</h1>
+            <h1>{(showSpeakerStatuses ? t('months.monthEvents') : t('months.monthCfpDeadlines')).replace('{month}', translatedMonth)}</h1>
           <div className="eventsGridDisplay">
             {eventsByMonth[month].map((e, i) => {
               const eventId = `${e.name}-${e.date[0]}`;
@@ -64,14 +66,15 @@ const CfpView = () => {
                 <div className={`eventCell ${isFav ? 'favorite-event' : ''}`} key={`${month}_ev_${i}`}>
 
                   <div className="content">
-                    <div>
+                    <div className={showSpeakerStatuses ? 'cfp-companion-row' : ''}>
+                      <div className={showSpeakerStatuses ? 'cfp-companion-main' : ''}>
                       <span className="when"><ShortDate dates={e.date} /></span>
                       <div className="event-header">
                         <b>{e.hyperlink ? <a className="title" href={e.hyperlink} rel="noreferrer" target="_blank">{e.name}</a> : ''}</b>
                         <FavoriteButton event={e} />
                       </div>
 
-                      <CfpDeadline until={e.cfp.until} untilDate={e.cfp.untilDate} />
+                      {!showSpeakerStatuses ? <CfpDeadline until={e.cfp.until} untilDate={e.cfp.untilDate} /> : null}
 
                     <div className="country">
                       <span className="countryFlag">
@@ -92,11 +95,13 @@ const CfpView = () => {
                       <span>{e.sponsoring ? <a className="sponsoring" href={e.sponsoring} rel="noreferrer" target="_blank">💰</a> : null}</span>
                     </div>
                       <TagBadges onTagClick={handleTagClick} tags={e.tags} />
+                      </div>
+                      {showSpeakerStatuses ? <CfpSpeakerStatus eventId={eventId} /> : null}
                     </div>
-                    <a className="submitButton" href={e.cfp.link} rel="noreferrer" target="_blank" title={t('cfp.submitToCfp')}>
+                    {!showSpeakerStatuses ? <a className="submitButton" href={e.cfp.link} rel="noreferrer" target="_blank" title={t('cfp.submitToCfp')}>
                       <CalendarClock />
                       {t('cfp.submitToCfp')}
-                    </a>
+                    </a> : null}
                   </div>
                 </div>
               );

--- a/page/src/components/Filters/Filters.jsx
+++ b/page/src/components/Filters/Filters.jsx
@@ -229,7 +229,8 @@ const Filters = ({ view }) => {
 
         <div className='filtersList'>
 
-          {view === 'cfp-companion' ? <>
+          {view === 'cfp-companion' ? <fieldset className='cfp-companion-status-filters'>
+            <legend>{t('filters.cfpStatus')}</legend>
             <div className='filtersItem'>
               <input checked={(search.cfpStatus || '').split(',').includes('pending')} id='filter-cfp-pending' onChange={(event) => {
                 const statuses = new Set((search.cfpStatus || '').split(',').filter(Boolean))
@@ -254,7 +255,7 @@ const Filters = ({ view }) => {
               }} type='checkbox' />
               <label htmlFor='filter-cfp-rejected'>{t('filters.cfpRejected')}</label>
             </div>
-          </> : null}
+          </fieldset> : null}
 
           {view != "cfp" && view !== 'cfp-companion' ?
           <div className='filtersItem'>

--- a/page/src/components/Filters/Filters.jsx
+++ b/page/src/components/Filters/Filters.jsx
@@ -145,6 +145,7 @@ const Filters = ({ view }) => {
     filterKeys.add('favorites')
     filterKeys.add('query')
     filterKeys.add('untilDate')
+    filterKeys.add('cfpStatus')
 
     Object.keys(search).forEach(k => {
       if (!filterKeys.has(k)) {
@@ -221,14 +222,41 @@ const Filters = ({ view }) => {
           />
         </> : null}
 
-        <div className='filtersItem'>
+        {view !== 'cfp-companion' ? <div className='filtersItem'>
           <label htmlFor='filter-until'>{t('filters.cfpUntil')}</label>
           <input id="filter-until" onChange={(e) => onChange('untilDate', e.target.value)} type="date" value={search.untilDate || ''} />
-        </div>
+        </div> : null}
 
         <div className='filtersList'>
 
-          {view != "cfp" ?
+          {view === 'cfp-companion' ? <>
+            <div className='filtersItem'>
+              <input checked={(search.cfpStatus || '').split(',').includes('pending')} id='filter-cfp-pending' onChange={(event) => {
+                const statuses = new Set((search.cfpStatus || '').split(',').filter(Boolean))
+                event.target.checked ? statuses.add('pending') : statuses.delete('pending')
+                onChange('cfpStatus', Array.from(statuses).join(','))
+              }} type='checkbox' />
+              <label htmlFor='filter-cfp-pending'>{t('filters.cfpPending')}</label>
+            </div>
+            <div className='filtersItem'>
+              <input checked={(search.cfpStatus || '').split(',').includes('accepted')} id='filter-cfp-accepted' onChange={(event) => {
+                const statuses = new Set((search.cfpStatus || '').split(',').filter(Boolean))
+                event.target.checked ? statuses.add('accepted') : statuses.delete('accepted')
+                onChange('cfpStatus', Array.from(statuses).join(','))
+              }} type='checkbox' />
+              <label htmlFor='filter-cfp-accepted'>{t('filters.cfpAccepted')}</label>
+            </div>
+            <div className='filtersItem'>
+              <input checked={(search.cfpStatus || '').split(',').includes('rejected')} id='filter-cfp-rejected' onChange={(event) => {
+                const statuses = new Set((search.cfpStatus || '').split(',').filter(Boolean))
+                event.target.checked ? statuses.add('rejected') : statuses.delete('rejected')
+                onChange('cfpStatus', Array.from(statuses).join(','))
+              }} type='checkbox' />
+              <label htmlFor='filter-cfp-rejected'>{t('filters.cfpRejected')}</label>
+            </div>
+          </> : null}
+
+          {view != "cfp" && view !== 'cfp-companion' ?
           <div className='filtersItem'>
             <input checked={search.callForPapers == 'true'} id='filter-call-for-papers' onChange={(e) => onChange('callForPapers', e.target.checked)} type='checkbox' />
             <label htmlFor='filter-call-for-papers'>{t('filters.callForPapersOpen')}</label>

--- a/page/src/components/ViewSelector/ViewSelector.jsx
+++ b/page/src/components/ViewSelector/ViewSelector.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {useNavigate, useSearchParams, createSearchParams, useParams} from "react-router-dom";
 import { useTranslation } from 'contexts/LanguageContext';
 import 'styles/ViewSelector.css';
-import {Calendar, List, Map, Megaphone} from 'lucide-react';
+import {Calendar, List, Map, Megaphone, Mic} from 'lucide-react';
 
 const ViewSelector = ({selected}) => {
   const navigate = useNavigate();
@@ -18,6 +18,13 @@ const ViewSelector = ({selected}) => {
         onClick={() => navigate(`/${year}/cfp?${createSearchParams(searchParams)}`)}
         size="42px"
         title={t('nav.cfp')}
+      />
+      <Mic
+        aria-label={t('nav.cfpCompanion')}
+        className={selected === 'cfp-companion' ? 'view-selector cfp-companion-view selected' : 'view-selector cfp-companion-view'}
+        onClick={() => navigate(`/${year}/cfp-companion?${createSearchParams(searchParams)}`)}
+        size="42px"
+        title={t('nav.cfpCompanion')}
       />
       <Calendar
         aria-label={t('nav.calendar')}

--- a/page/src/components/YearSelector/YearSelector.jsx
+++ b/page/src/components/YearSelector/YearSelector.jsx
@@ -4,12 +4,14 @@ import { ArrowLeftCircle, ArrowRightCircle } from 'lucide-react';
 
 
 import 'styles/YearSelector.css';
-import { useYearEvents, useCfpEvents } from 'app.hooks';
+import { useYearEvents, useCfpCompanionEvents, useCfpEvents } from 'app.hooks';
 import EventCount from 'components/EventCount/EventCount';
 import ViewSelector from 'components/ViewSelector/ViewSelector';
 
 const YearSelector = ({ isMap, year, onChange, view }) => {
-  const yearEvents = view === "cfp" ? useCfpEvents() : useYearEvents();
+  const yearEvents = view === "cfp" || view === "cfp-companion" ? useCfpEvents() : useYearEvents();
+  const companionEvents = useCfpCompanionEvents();
+  const displayedEvents = view === "cfp-companion" ? companionEvents : yearEvents;
   return (
     <div>
       <div className="yearNavigatorWrapper">
@@ -21,7 +23,7 @@ const YearSelector = ({ isMap, year, onChange, view }) => {
         <ViewSelector selected={view}/>
       </div>
       <div>
-        <EventCount events={yearEvents} isMap={isMap} />
+        <EventCount events={displayedEvents} isMap={isMap} />
       </div>
     </div>
   );

--- a/page/src/locales/de.json
+++ b/page/src/locales/de.json
@@ -22,7 +22,8 @@
     "calendar": "Kalender",
     "map": "Karte",
     "list": "Liste",
-    "cfp": "CFPs"
+    "cfp": "CFPs",
+    "cfpCompanion": "CFP-Begleiter"
   },
   "filters": {
     "title": "Filter",
@@ -118,7 +119,11 @@
     "submit": "Vorschlag einreichen",
     "viewCfp": "CFP ansehen",
     "submitToCfp": "CFP einreichen",
-    "until": "Bis zum"
+    "until": "Bis zum",
+    "companionStatus": "Mein CFP-Status",
+    "applied": "Beworben",
+    "accepted": "Angenommen",
+    "rejected": "Abgelehnt"
   },
   "map": {
     "title": "Konferenzkarte",

--- a/page/src/locales/de.json
+++ b/page/src/locales/de.json
@@ -63,7 +63,10 @@
     "anyTag": "IRGENDEINEN Tag zuordnen",
     "allTags": "ALLE Tags zuordnen",
     "excludeMode": "Ausgewählte Tags ausschließen",
-    "includeMode": "Ausgewählte Tags einschließen"
+    "includeMode": "Ausgewählte Tags einschließen",
+    "cfpPending": "Antwort ausstehend",
+    "cfpAccepted": "Angenommen",
+    "cfpRejected": "Abgelehnt"
   },
   "calendar": {
     "today": "Heute",

--- a/page/src/locales/de.json
+++ b/page/src/locales/de.json
@@ -66,7 +66,8 @@
     "includeMode": "Ausgewählte Tags einschließen",
     "cfpPending": "Antwort ausstehend",
     "cfpAccepted": "Angenommen",
-    "cfpRejected": "Abgelehnt"
+    "cfpRejected": "Abgelehnt",
+    "cfpStatus": "CFP-Status"
   },
   "calendar": {
     "today": "Heute",

--- a/page/src/locales/en.json
+++ b/page/src/locales/en.json
@@ -63,7 +63,10 @@
     "anyTag": "Match ANY tag",
     "allTags": "Match ALL tags",
     "excludeMode": "Exclude selected tags",
-    "includeMode": "Include selected tags"
+    "includeMode": "Include selected tags",
+    "cfpPending": "Pending response",
+    "cfpAccepted": "Accepted",
+    "cfpRejected": "Rejected"
   },
   "calendar": {
     "today": "Today",

--- a/page/src/locales/en.json
+++ b/page/src/locales/en.json
@@ -22,7 +22,8 @@
     "calendar": "Calendar",
     "map": "Map",
     "list": "List",
-    "cfp": "CFPs"
+    "cfp": "CFPs",
+    "cfpCompanion": "CFP Companion"
   },
   "filters": {
     "title": "Filters",
@@ -118,7 +119,11 @@
     "submit": "Submit proposal",
     "viewCfp": "View CFP",
     "submitToCfp": "Submit to the CFP",
-    "until": "Until"
+    "until": "Until",
+    "companionStatus": "My CFP status",
+    "applied": "Applied",
+    "accepted": "Accepted",
+    "rejected": "Rejected"
   },
   "map": {
     "title": "Conference Map",

--- a/page/src/locales/en.json
+++ b/page/src/locales/en.json
@@ -66,7 +66,8 @@
     "includeMode": "Include selected tags",
     "cfpPending": "Pending response",
     "cfpAccepted": "Accepted",
-    "cfpRejected": "Rejected"
+    "cfpRejected": "Rejected",
+    "cfpStatus": "CFP status"
   },
   "calendar": {
     "today": "Today",

--- a/page/src/locales/es.json
+++ b/page/src/locales/es.json
@@ -22,7 +22,8 @@
     "calendar": "Calendario",
     "map": "Mapa",
     "list": "Lista",
-    "cfp": "CFPs"
+    "cfp": "CFPs",
+    "cfpCompanion": "Asistente de CFP"
   },
   "filters": {
     "title": "Filtros",
@@ -118,7 +119,11 @@
     "submit": "Enviar propuesta",
     "viewCfp": "Ver CFP",
     "submitToCfp": "Enviar al CFP",
-    "until": "Hasta el"
+    "until": "Hasta el",
+    "companionStatus": "Mi estado CFP",
+    "applied": "Solicitud enviada",
+    "accepted": "Aceptada",
+    "rejected": "Rechazada"
   },
   "map": {
     "title": "Mapa de Conferencias",

--- a/page/src/locales/es.json
+++ b/page/src/locales/es.json
@@ -63,7 +63,10 @@
     "anyTag": "Coincidir con CUALQUIER etiqueta",
     "allTags": "Coincidir con TODAS las etiquetas",
     "excludeMode": "Excluir etiquetas seleccionadas",
-    "includeMode": "Incluir etiquetas seleccionadas"
+    "includeMode": "Incluir etiquetas seleccionadas",
+    "cfpPending": "Pendiente de respuesta",
+    "cfpAccepted": "Aceptadas",
+    "cfpRejected": "Rechazadas"
   },
   "calendar": {
     "today": "Hoy",

--- a/page/src/locales/es.json
+++ b/page/src/locales/es.json
@@ -66,7 +66,8 @@
     "includeMode": "Incluir etiquetas seleccionadas",
     "cfpPending": "Pendiente de respuesta",
     "cfpAccepted": "Aceptadas",
-    "cfpRejected": "Rechazadas"
+    "cfpRejected": "Rechazadas",
+    "cfpStatus": "Estado del CFP"
   },
   "calendar": {
     "today": "Hoy",

--- a/page/src/locales/fr.json
+++ b/page/src/locales/fr.json
@@ -63,7 +63,10 @@
     "anyTag": "Correspondre à N'IMPORTE QUEL tag",
     "allTags": "Correspondre à TOUS les tags",
     "excludeMode": "Exclure les tags sélectionnés",
-    "includeMode": "Inclure les tags sélectionnés"
+    "includeMode": "Inclure les tags sélectionnés",
+    "cfpPending": "En attente",
+    "cfpAccepted": "Acceptés",
+    "cfpRejected": "Refusés"
   },
   "calendar": {
     "today": "Aujourd'hui",

--- a/page/src/locales/fr.json
+++ b/page/src/locales/fr.json
@@ -22,7 +22,8 @@
     "calendar": "Calendrier",
     "map": "Carte",
     "list": "Liste",
-    "cfp": "CFPs"
+    "cfp": "CFPs",
+    "cfpCompanion": "Compagnon CFP"
   },
   "filters": {
     "title": "Filtres",
@@ -118,7 +119,11 @@
     "submit": "Soumettre une proposition",
     "viewCfp": "Voir le CFP",
     "submitToCfp": "Soumettre au CFP",
-    "until": "Jusqu'au"
+    "until": "Jusqu'au",
+    "companionStatus": "Mon statut CFP",
+    "applied": "Candidature envoyée",
+    "accepted": "Acceptée",
+    "rejected": "Refusée"
   },
   "map": {
     "title": "Carte des Conférences",

--- a/page/src/locales/fr.json
+++ b/page/src/locales/fr.json
@@ -66,7 +66,8 @@
     "includeMode": "Inclure les tags sélectionnés",
     "cfpPending": "En attente",
     "cfpAccepted": "Acceptés",
-    "cfpRejected": "Refusés"
+    "cfpRejected": "Refusés",
+    "cfpStatus": "Statut CFP"
   },
   "calendar": {
     "today": "Aujourd'hui",

--- a/page/src/locales/pt.json
+++ b/page/src/locales/pt.json
@@ -63,7 +63,10 @@
     "anyTag": "Corresponder a QUALQUER tag",
     "allTags": "Corresponder a TODAS as tags",
     "excludeMode": "Excluir tags selecionadas",
-    "includeMode": "Incluir tags selecionadas"
+    "includeMode": "Incluir tags selecionadas",
+    "cfpPending": "Aguardando resposta",
+    "cfpAccepted": "Aceitas",
+    "cfpRejected": "Recusadas"
   },
   "calendar": {
     "today": "Hoje",

--- a/page/src/locales/pt.json
+++ b/page/src/locales/pt.json
@@ -22,7 +22,8 @@
     "calendar": "Calendário",
     "map": "Mapa",
     "list": "Lista",
-    "cfp": "CFPs"
+    "cfp": "CFPs",
+    "cfpCompanion": "Assistente CFP"
   },
   "filters": {
     "title": "Filtros",
@@ -118,7 +119,11 @@
     "submit": "Enviar proposta",
     "viewCfp": "Ver CFP",
     "submitToCfp": "Enviar para CFP",
-    "until": "Até"
+    "until": "Até",
+    "companionStatus": "Meu status CFP",
+    "applied": "Candidatura enviada",
+    "accepted": "Aceita",
+    "rejected": "Recusada"
   },
   "map": {
     "title": "Mapa de Conferências",

--- a/page/src/locales/pt.json
+++ b/page/src/locales/pt.json
@@ -66,7 +66,8 @@
     "includeMode": "Incluir tags selecionadas",
     "cfpPending": "Aguardando resposta",
     "cfpAccepted": "Aceitas",
-    "cfpRejected": "Recusadas"
+    "cfpRejected": "Recusadas",
+    "cfpStatus": "Status do CFP"
   },
   "calendar": {
     "today": "Hoje",

--- a/page/src/misc/lastVisitedView.js
+++ b/page/src/misc/lastVisitedView.js
@@ -1,7 +1,7 @@
 export const LAST_VISITED_VIEW_KEY = 'dca:lastVisitedView'
 export const DEFAULT_VIEW = 'calendar'
 
-const VALID_VIEWS = ['cfp', 'calendar', 'list', 'map']
+const VALID_VIEWS = ['cfp', 'cfp-companion', 'calendar', 'list', 'map']
 const VALID_VIEWS_SET = new Set(VALID_VIEWS)
 
 export const isValidView = (view) => VALID_VIEWS_SET.has(view)
@@ -11,7 +11,7 @@ export const extractViewFromPath = (pathname = '') => {
     return null
   }
 
-  const match = pathname.match(/^\/\d{4}\/(cfp|calendar|list|map)(?:\/|$)/)
+  const match = pathname.match(/^\/\d{4}\/(cfp-companion|cfp|calendar|list|map)(?:\/|$)/)
   return match ? match[1] : null
 }
 

--- a/page/src/routes/cfpcompanionpage.jsx
+++ b/page/src/routes/cfpcompanionpage.jsx
@@ -1,0 +1,30 @@
+import Filters from 'components/Filters/Filters'
+import CfpCompanionView from 'components/CfpCompanionView/CfpCompanionView'
+import YearSelector from 'components/YearSelector/YearSelector'
+import { createSearchParams, useNavigate, useParams, useSearchParams } from 'react-router-dom'
+import { useCfpCompanionEvents } from 'app.hooks'
+
+export const CfpCompanionPage = () => {
+  const { year } = useParams()
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const events = useCfpCompanionEvents()
+
+  return (
+    <div className="dcaGrid">
+      <Filters view="cfp-companion" />
+      <div className="dcaContent">
+        <YearSelector
+          isMap={false}
+          onChange={nextYear => {
+            navigate(`/${nextYear}/cfp-companion?${createSearchParams(searchParams)}`)
+          }}
+          view="cfp-companion"
+          year={parseInt(year, 10)}
+        />
+
+        <CfpCompanionView events={events} />
+      </div>
+    </div>
+  )
+}

--- a/page/src/styles/CfpCompanionView.css
+++ b/page/src/styles/CfpCompanionView.css
@@ -1,0 +1,23 @@
+.cfp-companion-view .event-list-entry {
+  gap: 1rem;
+}
+
+.cfp-companion-view .event-date-fav {
+  padding-right: 0;
+  width: 10rem;
+}
+
+.cfp-companion-view .cfp-speaker-status {
+  flex-shrink: 0;
+  margin: 0;
+}
+
+@media screen and (max-width: 1024px) {
+  .cfp-companion-view .event-list-entry {
+    align-items: flex-start;
+  }
+
+  .cfp-companion-view .event-details {
+    width: 100%;
+  }
+}

--- a/page/src/styles/CfpSpeakerStatus.css
+++ b/page/src/styles/CfpSpeakerStatus.css
@@ -1,0 +1,38 @@
+.cfp-speaker-status {
+  align-items: center;
+  display: flex;
+  gap: 0.4rem;
+  margin: 0.75rem 1rem 0;
+}
+
+.cfp-speaker-status-button {
+  align-items: center;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 3px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  display: inline-flex;
+  height: 2.25rem;
+  justify-content: center;
+  padding: 0;
+  width: 2.25rem;
+}
+
+.cfp-speaker-status-button.selected.applied {
+  background: var(--color-cta);
+  border-color: var(--color-cta);
+  color: white;
+}
+
+.cfp-speaker-status-button.selected.accepted {
+  background: #287a4e;
+  border-color: #287a4e;
+  color: white;
+}
+
+.cfp-speaker-status-button.selected.rejected {
+  background: #b53636;
+  border-color: #b53636;
+  color: white;
+}

--- a/page/src/styles/CfpView.css
+++ b/page/src/styles/CfpView.css
@@ -213,6 +213,45 @@
     color: var(--color-favorite);
 }
 
+.cfpView.cfp-companion .eventsGridDisplay {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 0;
+}
+
+.cfpView.cfp-companion .eventCell {
+    width: 100%;
+}
+
+.cfpView.cfp-companion .cfp-companion-row {
+    align-items: center;
+    display: flex;
+    flex-direction: row;
+    gap: 1rem;
+}
+
+.cfpView.cfp-companion .cfp-companion-main {
+    flex: 1;
+    min-width: 0;
+}
+
+.cfpView.cfp-companion .cfp-speaker-status {
+    flex-shrink: 0;
+    margin: 0 1rem;
+}
+
+@media screen and (max-width: 660px) {
+    .cfpView.cfp-companion .cfp-companion-row {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+
+    .cfpView.cfp-companion .cfp-speaker-status {
+        margin: 0.75rem 1rem 0;
+    }
+}
+
 .sponsoring {
     text-decoration: none;
     font-size: 1.6rem;

--- a/page/src/styles/Filters.css
+++ b/page/src/styles/Filters.css
@@ -104,6 +104,22 @@
     margin: 2rem 0;
 }
 
+.cfp-companion-status-filters {
+    border: 1px solid var(--border-color);
+    border-radius: 3px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin: 0 0 0.75rem;
+    padding: 0.75rem;
+}
+
+.cfp-companion-status-filters legend {
+    color: var(--text-secondary);
+    font-weight: 600;
+    padding: 0 0.4rem;
+}
+
 .filters .filtersItem {
     overflow: hidden;
     white-space: nowrap;

--- a/page/src/utils/cfpSpeakerStatuses.js
+++ b/page/src/utils/cfpSpeakerStatuses.js
@@ -18,15 +18,34 @@ const saveStatuses = (statuses) => {
   }
 }
 
-export const getCfpSpeakerStatus = (eventId) => getStatuses()[eventId]
+const normalizeStatus = (status) => {
+  if (typeof status === 'string') {
+    return {
+      applied: status === 'applied',
+      outcome: status === 'accepted' || status === 'rejected' ? status : undefined
+    }
+  }
+
+  return status || { applied: false, outcome: undefined }
+}
+
+export const getCfpSpeakerStatus = (eventId) => normalizeStatus(getStatuses()[eventId])
 
 export const setCfpSpeakerStatus = (eventId, status) => {
   const statuses = getStatuses()
+  const currentStatus = normalizeStatus(statuses[eventId])
+  const nextStatus = { ...currentStatus }
 
-  if (statuses[eventId] === status) {
+  if (status === 'applied') {
+    nextStatus.applied = !currentStatus.applied
+  } else {
+    nextStatus.outcome = currentStatus.outcome === status ? undefined : status
+  }
+
+  if (!nextStatus.applied && !nextStatus.outcome) {
     delete statuses[eventId]
   } else {
-    statuses[eventId] = status
+    statuses[eventId] = nextStatus
   }
 
   saveStatuses(statuses)

--- a/page/src/utils/cfpSpeakerStatuses.js
+++ b/page/src/utils/cfpSpeakerStatuses.js
@@ -31,6 +31,21 @@ const normalizeStatus = (status) => {
 
 export const getCfpSpeakerStatus = (eventId) => normalizeStatus(getStatuses()[eventId])
 
+export const filterEventsBySpeakerStatus = (events, selectedStatuses) => {
+  if (selectedStatuses.length === 0) {
+    return events
+  }
+
+  return events.filter(event => {
+    const status = getCfpSpeakerStatus(`${event.name}-${event.date[0]}`)
+    return (
+      (selectedStatuses.includes('pending') && status.applied && !status.outcome)
+      || (selectedStatuses.includes('accepted') && status.outcome === 'accepted')
+      || (selectedStatuses.includes('rejected') && status.outcome === 'rejected')
+    )
+  })
+}
+
 export const setCfpSpeakerStatus = (eventId, status) => {
   const statuses = getStatuses()
   const currentStatus = normalizeStatus(statuses[eventId])
@@ -39,6 +54,7 @@ export const setCfpSpeakerStatus = (eventId, status) => {
   if (status === 'applied') {
     nextStatus.applied = !currentStatus.applied
   } else {
+    nextStatus.applied = true
     nextStatus.outcome = currentStatus.outcome === status ? undefined : status
   }
 

--- a/page/src/utils/cfpSpeakerStatuses.js
+++ b/page/src/utils/cfpSpeakerStatuses.js
@@ -1,0 +1,33 @@
+const CFP_SPEAKER_STATUSES_KEY = 'developer-conferences-cfp-speaker-statuses'
+
+const getStatuses = () => {
+  try {
+    const statuses = localStorage.getItem(CFP_SPEAKER_STATUSES_KEY)
+    return statuses ? JSON.parse(statuses) : {}
+  } catch (error) {
+    console.error('Error loading CFP speaker statuses:', error)
+    return {}
+  }
+}
+
+const saveStatuses = (statuses) => {
+  try {
+    localStorage.setItem(CFP_SPEAKER_STATUSES_KEY, JSON.stringify(statuses))
+  } catch (error) {
+    console.error('Error saving CFP speaker statuses:', error)
+  }
+}
+
+export const getCfpSpeakerStatus = (eventId) => getStatuses()[eventId]
+
+export const setCfpSpeakerStatus = (eventId, status) => {
+  const statuses = getStatuses()
+
+  if (statuses[eventId] === status) {
+    delete statuses[eventId]
+  } else {
+    statuses[eventId] = status
+  }
+
+  saveStatuses(statuses)
+}

--- a/page/src/utils/cfpSpeakerStatuses.test.js
+++ b/page/src/utils/cfpSpeakerStatuses.test.js
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getCfpSpeakerStatus, setCfpSpeakerStatus } from './cfpSpeakerStatuses'
+
+describe('CFP speaker statuses', () => {
+  const eventId = 'Test Conference-2026-06-01'
+  const storage = new Map()
+
+  beforeEach(() => {
+    storage.clear()
+    vi.stubGlobal('localStorage', {
+      getItem: vi.fn(key => storage.get(key) || null),
+      setItem: vi.fn((key, value) => storage.set(key, value))
+    })
+  })
+
+  it('stores a speaker status for an event', () => {
+    setCfpSpeakerStatus(eventId, 'applied')
+
+    expect(getCfpSpeakerStatus(eventId)).toBe('applied')
+  })
+
+  it('replaces a status with the newly selected one', () => {
+    setCfpSpeakerStatus(eventId, 'applied')
+    setCfpSpeakerStatus(eventId, 'accepted')
+
+    expect(getCfpSpeakerStatus(eventId)).toBe('accepted')
+  })
+
+  it('removes a status when it is selected again', () => {
+    setCfpSpeakerStatus(eventId, 'rejected')
+    setCfpSpeakerStatus(eventId, 'rejected')
+
+    expect(getCfpSpeakerStatus(eventId)).toBeUndefined()
+  })
+})

--- a/page/src/utils/cfpSpeakerStatuses.test.js
+++ b/page/src/utils/cfpSpeakerStatuses.test.js
@@ -17,20 +17,24 @@ describe('CFP speaker statuses', () => {
   it('stores a speaker status for an event', () => {
     setCfpSpeakerStatus(eventId, 'applied')
 
-    expect(getCfpSpeakerStatus(eventId)).toBe('applied')
+    expect(getCfpSpeakerStatus(eventId)).toEqual({ applied: true, outcome: undefined })
   })
 
-  it('replaces a status with the newly selected one', () => {
+  it('keeps an application when an outcome is selected', () => {
     setCfpSpeakerStatus(eventId, 'applied')
     setCfpSpeakerStatus(eventId, 'accepted')
 
-    expect(getCfpSpeakerStatus(eventId)).toBe('accepted')
+    expect(getCfpSpeakerStatus(eventId)).toEqual({ applied: true, outcome: 'accepted' })
   })
 
-  it('removes a status when it is selected again', () => {
-    setCfpSpeakerStatus(eventId, 'rejected')
+  it('replaces an outcome and clears it when selected again', () => {
+    setCfpSpeakerStatus(eventId, 'accepted')
     setCfpSpeakerStatus(eventId, 'rejected')
 
-    expect(getCfpSpeakerStatus(eventId)).toBeUndefined()
+    expect(getCfpSpeakerStatus(eventId)).toEqual({ applied: false, outcome: 'rejected' })
+
+    setCfpSpeakerStatus(eventId, 'rejected')
+
+    expect(getCfpSpeakerStatus(eventId)).toEqual({ applied: false, outcome: undefined })
   })
 })

--- a/page/src/utils/cfpSpeakerStatuses.test.js
+++ b/page/src/utils/cfpSpeakerStatuses.test.js
@@ -20,8 +20,7 @@ describe('CFP speaker statuses', () => {
     expect(getCfpSpeakerStatus(eventId)).toEqual({ applied: true, outcome: undefined })
   })
 
-  it('keeps an application when an outcome is selected', () => {
-    setCfpSpeakerStatus(eventId, 'applied')
+  it('activates an application when an outcome is selected', () => {
     setCfpSpeakerStatus(eventId, 'accepted')
 
     expect(getCfpSpeakerStatus(eventId)).toEqual({ applied: true, outcome: 'accepted' })
@@ -31,10 +30,10 @@ describe('CFP speaker statuses', () => {
     setCfpSpeakerStatus(eventId, 'accepted')
     setCfpSpeakerStatus(eventId, 'rejected')
 
-    expect(getCfpSpeakerStatus(eventId)).toEqual({ applied: false, outcome: 'rejected' })
+    expect(getCfpSpeakerStatus(eventId)).toEqual({ applied: true, outcome: 'rejected' })
 
     setCfpSpeakerStatus(eventId, 'rejected')
 
-    expect(getCfpSpeakerStatus(eventId)).toEqual({ applied: false, outcome: undefined })
+    expect(getCfpSpeakerStatus(eventId)).toEqual({ applied: true, outcome: undefined })
   })
 })


### PR DESCRIPTION
**Summary**
Adds a dedicated "CFP Companion" view for speakers to follow their CFP submissions throughout the conference lifecycle.

The new view is available from the view selector via a microphone icon:
<img width="334" height="177" alt="image" src="https://github.com/user-attachments/assets/4af0ab84-ff36-4ca6-b220-fecfa9a6a96f" />

It lists conferences by their event date, including conferences whose CFP is already closed:

<img width="1439" height="402" alt="image" src="https://github.com/user-attachments/assets/3d80ef5c-51f9-4fb1-9daa-3a18325ca8a9" />

It's also possible to filter on the CFP status:

<img width="346" height="637" alt="image" src="https://github.com/user-attachments/assets/ffdf18dc-8c4f-46f7-b1fc-944e5106f07a" />


**Changes**
- Shows conferences for the selected event year that have CFP metadata, regardless of CFP closing date.
- Added persistent per-conference speaker tracking stored in localStorage:
  - Applied
  - Accepted
  - Rejected
- Applied can be combined with either outcome. Accepted and Rejected remain mutually exclusive. Clicking an active status clears it.
- Added translations in English, French, German, Spanish and Portuguese.
- Updated last-visited-view handling for the new route.
- Added unit coverage for the Companion event filtering and persisted status behavior.

**Demo**

https://github.com/user-attachments/assets/ae20b0fe-5211-4a0d-a429-1bfd23d28caa

Fixes #3359 